### PR TITLE
Add user authentication using Guisso

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,12 +9,19 @@
                  [duct "0.6.1"]
 
                  ; Web server and routing
-                 [compojure "1.5.0"]
+                 [compojure "1.5.0"
+                  :exclusions [commons-codec]]
                  [ring "1.4.0"]
                  [ring/ring-defaults "0.2.0"]
                  [ring/ring-json "0.4.0"]
                  [ring-jetty-component "0.3.1"]
                  [ring-webjars "0.1.1"]
+
+                 ; Security
+                 [buddy "1.0.0"]
+                 [org.openid4java/openid4java "1.0.0"
+                  :exclusions [commons-logging
+                               org.apache.httpcomponents/httpclient]]
 
                  ; Configuration
                  [environ "1.0.3"]

--- a/resources/migrations/007-users.down.sql
+++ b/resources/migrations/007-users.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS users;

--- a/resources/migrations/007-users.up.sql
+++ b/resources/migrations/007-users.up.sql
@@ -1,9 +1,9 @@
 CREATE TABLE users (
-       id BIGINT PRIMARY KEY,
-       email VARCHAR(255) NOT NULL,
+       id BIGSERIAL PRIMARY KEY,
+       email VARCHAR(255) UNIQUE NOT NULL,
        full_name VARCHAR(255),
-       last_login TIMESTAMP,
-       created_at TIMESTAMP NOT NULL
+       last_login TIMESTAMP WITH TIME ZONE,
+       created_at TIMESTAMP WITH TIME ZONE NOT NULL
 );
 
 CREATE INDEX users_email_idx ON users (email);

--- a/resources/migrations/007-users.up.sql
+++ b/resources/migrations/007-users.up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE users (
+       id BIGINT PRIMARY KEY,
+       email VARCHAR(255) NOT NULL,
+       full_name VARCHAR(255),
+       last_login TIMESTAMP,
+       created_at TIMESTAMP NOT NULL
+);
+
+CREATE INDEX users_email_idx ON users (email);

--- a/resources/planwise/errors/403.html
+++ b/resources/planwise/errors/403.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en" class="error-page">
+  <head>
+    <title>Server Error</title>
+    <link rel="stylesheet" href="/assets/normalize.css/normalize.css">
+    <link rel="stylesheet" href="/css/site.css">
+  </head>
+  <body>
+    <h1>Access denied</h1>
+    <h2>You don't have enough permissions to access this page</h2>
+  </body>
+</html>

--- a/resources/planwise/sql/users.sql
+++ b/resources/planwise/sql/users.sql
@@ -1,0 +1,19 @@
+-- :name select-user :? :1
+SELECT id, email, full_name, last_login
+FROM users
+WHERE id = :id;
+
+-- :name select-user-by-email :? :1
+SELECT id, email, full_name, last_login
+FROM users
+WHERE email = :email;
+
+-- :name create-user! :<!
+INSERT INTO users (email, full_name, created_at)
+       VALUES(:email, :full_name, 'now')
+       RETURNING id;
+
+-- :name update-last-login! :! :n
+UPDATE users
+SET last_login = 'now'
+WHERE id = :id;

--- a/resources/sass/_layout.scss
+++ b/resources/sass/_layout.scss
@@ -101,4 +101,10 @@ header {
       }
     }
   }
+
+  .user-info {
+    flex-grow: 0;
+    margin-top: 20px;
+    margin-right: 10px;
+  }
 }

--- a/src/planwise/client/api.cljs
+++ b/src/planwise/client/api.cljs
@@ -16,7 +16,18 @@
                                 (assoc-in req [:headers "X-CSRF-Token"] @csrf-token)
                                 req))}))
 
-(swap! default-interceptors (partial cons csrf-token-interceptor))
+;; Add interceptor to send JWT encrypted token authentication with all requests
+
+(def jwe-token
+  (atom (.-value (.getElementById js/document "__jwe-token"))))
+
+(def jwe-token-interceptor
+  (to-interceptor {:name "JWE Token Interceptor"
+                   :request (fn [req]
+                              (let [auth-value (str "Token " @jwe-token)]
+                                (assoc-in req [:headers "Authorization"] auth-value)))}))
+
+(swap! default-interceptors into [csrf-token-interceptor jwe-token-interceptor])
 
 
 ;; Common request definitions to use with ajax requests

--- a/src/planwise/client/views.cljs
+++ b/src/planwise/client/views.cljs
@@ -10,6 +10,9 @@
   [{:item #{:home :projects} :href (routes/home) :title "Projects"}
    {:item :playground :href (routes/playground) :title "Playground"}])
 
+(def current-user-email
+  (atom (.-value (.getElementById js/document "__identity"))))
+
 (defn nav-bar []
   (let [current-page (subscribe [:current-page])]
     (fn []
@@ -17,7 +20,9 @@
         [:header
          [:a.logo {:href (routes/home)}
           [:h1 "PlanWise"]]
-         [:nav [common/ul-menu nav-items active]]]))))
+         [:nav [common/ul-menu nav-items active]]
+         [:div.user-info
+          @current-user-email]]))))
 
 (defmulti content-pane identity)
 

--- a/src/planwise/component/auth.clj
+++ b/src/planwise/component/auth.clj
@@ -1,0 +1,71 @@
+(ns planwise.component.auth
+  (:require [com.stuartsierra.component :as component]
+            [taoensso.timbre :as timbre]
+            [ring.util.request :refer [request-url]]
+            [ring.util.response :as resp]
+            [planwise.util.ring :refer [absolute-url]]
+            [planwise.auth.guisso :as guisso]))
+
+(timbre/refer-timbre)
+
+(defrecord AuthService [manager openid-identifier realm]
+  component/Lifecycle
+  (start [component]
+    (if-not (:manager component)
+      (assoc component :manager (guisso/openid-manager))
+      component))
+
+  (stop [component]
+    (assoc component :manager nil)))
+
+(defn auth-service
+  [config]
+  (map->AuthService config))
+
+
+(defn redirect
+  "Setup the OpenID associations and return a Ring response to redirect the user
+  to the OpenID login page"
+  [service request return-location]
+  (let [manager         (:manager service)
+        realm           (or (:realm service) (absolute-url "/" request))
+        identifier      (:openid-identifier service)
+        session         (:session request)
+        return-url      (absolute-url return-location request)
+        auth-request    (guisso/auth-request manager identifier return-url realm)
+        destination-url (:destination-url auth-request)
+        auth-state      (:auth-state auth-request)]
+    (assoc (resp/redirect destination-url)
+           :session (merge session {:openid-state auth-state}))))
+
+(defn validate
+  "Validates that the request contains a positive OpenID assertion and the
+  authenticated user information"
+  [service request]
+  (let [manager    (:manager service)
+        session    (:session request)
+        auth-state (:openid-state session)
+        url        (request-url request)
+        params     (:params request)]
+    (if auth-state
+      (if-let [authentication (guisso/auth-validate manager auth-state url params)]
+        authentication
+        (do
+          (info "Authentication failure")
+          nil))
+      (do
+        (warn "No OpenID request in session found")
+        nil))))
+
+(defn login
+  "Updates the response to alter the session to include the authenticated user"
+  [response request identity]
+  (let [user-email (:email identity)
+        session    (-> (:session request)
+                       (assoc :identity user-email))]
+    (assoc response :session session)))
+
+(defn logout
+  "Modifies the response to logout the currently authenticated user"
+  [response]
+  (assoc response :session nil))

--- a/src/planwise/component/compound_handler.clj
+++ b/src/planwise/component/compound_handler.clj
@@ -1,0 +1,39 @@
+(ns planwise.component.compound-handler
+  "Handler component which composes Duct handlers, otherwise identical in
+  functionality to Duct handlers"
+  (:require [com.stuartsierra.component :as component]
+            [compojure.core :as compojure]))
+
+(defn- find-handler-keys [component]
+  (sort (map key (filter (comp :handler val) component))))
+
+(defn- find-handlers [component]
+  (map #(:handler (get component %))
+       (:handlers component (find-handler-keys component))))
+
+(defn- middleware-fn [component middleware]
+  (if (vector? middleware)
+    (let [[f & keys] middleware
+          arguments  (map #(get component %) keys)]
+      #(apply f % arguments))
+    middleware))
+
+(defn- compose-middleware [{:keys [middleware] :as component}]
+  (->> (reverse middleware)
+       (map #(middleware-fn component %))
+       (apply comp identity)))
+
+(defrecord CompoundHandler [middleware]
+  component/Lifecycle
+  (start [component]
+    (if-not (:handler component)
+      (let [handlers (find-handlers component)
+            wrap-mw  (compose-middleware component)
+            handler  (wrap-mw (apply compojure/routes handlers))]
+        (assoc component :handler handler))
+      component))
+  (stop [component]
+    (dissoc component :handler)))
+
+(defn compound-handler-component [options]
+  (map->CompoundHandler options))

--- a/src/planwise/component/facilities.clj
+++ b/src/planwise/component/facilities.clj
@@ -8,8 +8,9 @@
 
 (hugsql/def-db-fns "planwise/sql/facilities.sql")
 
-(defn get-db [component]
+(defn get-db
   "Retrieve the database connection for a service"
+  [component]
   (get-in component [:db :spec]))
 
 
@@ -18,8 +19,9 @@
 
 (defrecord FacilitiesService [db])
 
-(defn facilities-service []
+(defn facilities-service
   "Construct a Facilities Service component"
+  []
   (map->FacilitiesService {}))
 
 

--- a/src/planwise/component/projects.clj
+++ b/src/planwise/component/projects.clj
@@ -17,8 +17,9 @@
 
 (defrecord ProjectsService [db])
 
-(defn projects-service []
+(defn projects-service
   "Constructs a Projects service component"
+  []
   (map->ProjectsService {}))
 
 

--- a/src/planwise/component/routing.clj
+++ b/src/planwise/component/routing.clj
@@ -17,8 +17,9 @@
 
 (defrecord RoutingService [db])
 
-(defn routing-service []
+(defn routing-service
   "Constructs a Routing service component"
+  []
   (map->RoutingService {}))
 
 

--- a/src/planwise/component/users.clj
+++ b/src/planwise/component/users.clj
@@ -1,0 +1,56 @@
+(ns planwise.component.users
+  (:require [com.stuartsierra.component :as component]
+            [taoensso.timbre :as timbre]
+            [clojure.java.jdbc :as jdbc]
+            [hugsql.core :as hugsql]))
+
+(timbre/refer-timbre)
+
+;; ----------------------------------------------------------------------
+;; Auxiliary and utility functions
+
+(hugsql/def-db-fns "planwise/sql/users.sql")
+
+(defn get-db
+  "Retrieve the database connection for a service"
+  [component]
+  (get-in component [:db :spec]))
+
+
+;; ----------------------------------------------------------------------
+;; Component definition
+
+(defrecord UsersStore [db])
+
+(defn users-store
+  "Construct a Users store component"
+  []
+  (map->UsersStore {}))
+
+
+(defn find-user
+  "Retrieves a single user by ID"
+  [service user-id]
+  (select-user (get-db service) {:id user-id}))
+
+(defn find-or-create-user-by-email
+  "Finds a user by email, creating it if it doesn't exist"
+  [service email]
+  (jdbc/with-db-transaction [tx (get-db service)]
+    (let [user (select-user-by-email tx {:email email})]
+      (if-not user
+        (let [user-id (-> (create-user! tx {:email email, :full_name nil})
+                          (first)
+                          (:id))]
+          (select-user tx {:id user-id}))
+        user))))
+
+(defn update-user-last-login!
+  "Updates the last login time for a given user ID"
+  [service user-id]
+  (let [affected-rows (update-last-login! (get-db service) {:id user-id})]
+    (if (= affected-rows 1)
+      true
+      (do
+        (error "Update last login for non-existent user for ID " user-id)
+        false))))

--- a/src/planwise/config.clj
+++ b/src/planwise/config.clj
@@ -7,4 +7,4 @@
 (def environ
   {:http {:port (some-> env :port Integer.)}
    :db   {:uri  (env :database-url)}
-   :auth {:openid-identifier (env :guisso-url)}})
+   :auth {:guisso-url (env :guisso-url)}})

--- a/src/planwise/config.clj
+++ b/src/planwise/config.clj
@@ -6,4 +6,5 @@
 
 (def environ
   {:http {:port (some-> env :port Integer.)}
-   :db   {:uri  (env :database-url)}})
+   :db   {:uri  (env :database-url)}
+   :auth {:openid-identifier (env :guisso-url)}})

--- a/src/planwise/endpoint/auth.clj
+++ b/src/planwise/endpoint/auth.clj
@@ -49,12 +49,12 @@
 
    (GET "/openidcallback" req
      (if-let [identity (auth/validate service req)]
-       (-> (redirect (next-url req))
-           (auth/login req identity))
+       (as-> (redirect (next-url req)) $
+           (auth/login service $ req identity))
        (-> (response failure-page)
            (content-type "text/html"))))
 
    (GET "/logout" []
      (-> (response logout-page)
          (content-type "text/html")
-         (auth/logout)))))
+         (auth/logout service)))))

--- a/src/planwise/endpoint/auth.clj
+++ b/src/planwise/endpoint/auth.clj
@@ -1,0 +1,42 @@
+(ns planwise.endpoint.auth
+  (:require [compojure.core :refer :all]
+            [ring.util.request :refer [request-url]]
+            [ring.util.response :refer [content-type response redirect header]]
+            [hiccup.page :refer [html5]]
+            [planwise.component.auth :as auth]))
+
+(def logout-page
+  (html5
+   [:body
+    [:p "Logged out"]
+    [:p [:a {:href "/login"} "Login"]]]))
+
+(def failure-page
+  (html5
+   [:body
+    [:p "Authentication failure"]
+    [:p [:a {:href "/login"} "Try again"]]]))
+
+(defn auth-endpoint [{service :auth}]
+  (routes
+   (GET "/identity" req
+     (let [id (:identity (:session req))]
+       (html5
+        [:body
+         [:p (str "Current identity: " id)]
+         [:p [:a {:href "/logout"} "Logout"]]])))
+
+   (GET "/login" req
+     (auth/redirect service req "/openidcallback?"))
+
+   (GET "/openidcallback" req
+     (if-let [identity (auth/validate service req)]
+       (-> (redirect "/identity")
+           (auth/login req identity))
+       (-> (response failure-page)
+           (content-type "text/html"))))
+
+   (GET "/logout" []
+     (-> (response logout-page)
+         (content-type "text/html")
+         (auth/logout)))))

--- a/src/planwise/endpoint/facilities.clj
+++ b/src/planwise/endpoint/facilities.clj
@@ -1,21 +1,27 @@
 (ns planwise.endpoint.facilities
   (:require [planwise.boundary.facilities :as facilities]
             [compojure.core :refer :all]
+            [buddy.auth.accessrules :refer [restrict]]
+            [buddy.auth :refer [authenticated?]]
             [ring.util.response :refer [response]]))
+
+(defn- endpoint-routes [service]
+  (routes
+   (GET "/" [] (let [facilities (facilities/list-facilities service)]
+                 (response facilities)))
+
+   (GET "/with-isochrones" [threshold algorithm simplify]
+     (let [facilities (facilities/list-with-isochrones service
+                                                       (Integer. threshold)
+                                                       algorithm
+                                                       (Float. simplify))]
+       (response facilities)))
+
+   (GET "/isochrone" [threshold]
+     (let [threshold (Integer. (or threshold 5400))
+           isochrone (facilities/isochrone-all-facilities service threshold)]
+       (response isochrone)))))
 
 (defn facilities-endpoint [{service :facilities}]
   (context "/api/facilities" []
-    (GET "/" [] (let [facilities (facilities/list-facilities service)]
-                  (response facilities)))
-
-    (GET "/with-isochrones" [threshold algorithm simplify]
-      (let [facilities (facilities/list-with-isochrones service
-                                                        (Integer. threshold)
-                                                        algorithm
-                                                        (Float. simplify))]
-        (response facilities)))
-
-    (GET "/isochrone" [threshold]
-      (let [threshold (Integer. (or threshold 5400))
-            isochrone (facilities/isochrone-all-facilities service threshold)]
-        (response isochrone)))))
+    (restrict (endpoint-routes service) {:handler authenticated?})))

--- a/src/planwise/endpoint/home.clj
+++ b/src/planwise/endpoint/home.clj
@@ -1,6 +1,7 @@
 (ns planwise.endpoint.home
   (:require [compojure.core :refer :all]
             [ring.util.anti-forgery :refer [anti-forgery-field]]
+            [buddy.auth :refer [authenticated? throw-unauthorized]]
             [hiccup.page :refer [include-js include-css html5]]))
 
 (def mount-target
@@ -18,15 +19,17 @@
    (include-css "/assets/leaflet/leaflet.css")
    (include-css "/css/site.css")])
 
-(defn loading-page [_]
-  (html5
-    (head)
-    [:body
-     mount-target
-     (anti-forgery-field)
-     (include-js "/assets/leaflet/leaflet.js")
-     (include-js "/js/main.js")
-     [:script "planwise.client.core.main();"]]))
+(defn loading-page [request]
+  (if-not (authenticated? request)
+    (throw-unauthorized)
+    (html5
+     (head)
+     [:body
+      mount-target
+      (anti-forgery-field)
+      (include-js "/assets/leaflet/leaflet.js")
+      (include-js "/js/main.js")
+      [:script "planwise.client.core.main();"]])))
 
 (defn home-endpoint [system]
   (routes

--- a/src/planwise/endpoint/home.clj
+++ b/src/planwise/endpoint/home.clj
@@ -3,6 +3,7 @@
             [ring.util.anti-forgery :refer [anti-forgery-field]]
             [buddy.auth :refer [authenticated? throw-unauthorized]]
             [planwise.component.auth :refer [create-jwe-token]]
+            [hiccup.form :refer [hidden-field]]
             [hiccup.page :refer [include-js include-css html5]]))
 
 (def mount-target
@@ -22,12 +23,12 @@
 
 (defn identity-field [request]
   (let [email (-> request :identity :user)]
-    [:input {:type :hidden :name "__identity" :value email}]))
+    (hidden-field "__identity" email)))
 
 (defn jwe-token-field [auth request]
   (let [email (-> request :identity :user)
         token (create-jwe-token auth email)]
-    [:input {:type :hidden :name "__jwe_token" :value token}]))
+    (hidden-field "__jwe-token" token)))
 
 (defn loading-page [auth request]
   (if-not (authenticated? request)

--- a/src/planwise/endpoint/monitor.clj
+++ b/src/planwise/endpoint/monitor.clj
@@ -1,0 +1,15 @@
+(ns planwise.endpoint.monitor
+  (:require [compojure.core :refer :all]
+            [ring.util.response :refer [response]]
+            [buddy.auth :refer [authenticated?]]
+            [buddy.auth.accessrules :refer [restrict]]))
+
+(defn whoami-handler [request]
+  (let [id (-> request :identity :user)]
+    (response {:email id})))
+
+(defn monitor-endpoint [system]
+  (context "/api" []
+    (GET "/ping" [] "pong")
+    (GET "/whoami" req
+      (restrict whoami-handler {:handler authenticated?}))))

--- a/src/planwise/endpoint/projects.clj
+++ b/src/planwise/endpoint/projects.clj
@@ -2,19 +2,24 @@
   (:require [compojure.core :refer :all]
             [ring.util.response :refer [content-type response not-found]]
             [clojure.data.json :as json]
+            [buddy.auth :refer [authenticated?]]
+            [buddy.auth.accessrules :refer [restrict]]
             [planwise.boundary.projects :as projects]))
+
+(defn- endpoint-routes [service]
+  (routes
+   (GET "/" []
+     (let [projects (projects/list-projects service)]
+       (response projects)))
+
+   (GET "/:id" [id]
+     (if-let [project (projects/get-project service (Integer/parseInt id))]
+       (response project)
+       (not-found {:error "Project not found"})))
+
+   (POST "/" [goal]
+     (response (projects/create-project service {:goal goal})))))
 
 (defn projects-endpoint [{service :projects}]
   (context "/api/projects" []
-
-    (GET "/" []
-      (let [projects (projects/list-projects service)]
-        (response projects)))
-
-    (GET "/:id" [id]
-      (if-let [project (projects/get-project service (Integer/parseInt id))]
-        (response project)
-        (not-found {:error "Project not found"})))
-
-    (POST "/" [goal]
-      (response (projects/create-project service {:goal goal})))))
+    (restrict (endpoint-routes service) {:handler authenticated?})))

--- a/src/planwise/system.clj
+++ b/src/planwise/system.clj
@@ -114,7 +114,8 @@
          :routing-endpoint    (endpoint-component routing-endpoint)
          :monitor-endpoint    (endpoint-component monitor-endpoint))
         (component/system-using
-         {:http                {:app :webapp}
+         {; Server and handlers
+          :http                {:app :webapp}
           :webapp              [:app :api]
           :api                 [:monitor-endpoint
                                 :facilities-endpoint
@@ -122,10 +123,15 @@
                                 :routing-endpoint]
           :app                 [:home-endpoint
                                 :auth-endpoint]
+
+          ; Components
           :facilities          [:db]
           :projects            [:db]
           :routing             [:db]
           :users-store         [:db]
+          :auth                [:users-store]
+
+          ; Endpoints
           :auth-endpoint       [:auth]
           :home-endpoint       [:auth]
           :facilities-endpoint [:facilities]

--- a/src/planwise/system.clj
+++ b/src/planwise/system.clj
@@ -13,10 +13,14 @@
             [ring.middleware.json :refer [wrap-json-response wrap-json-params]]
             [ring.middleware.webjars :refer [wrap-webjars]]
             [ring.middleware.session.cookie :refer [cookie-store]]
+            [compojure.response :as compojure]
+            [ring.util.response :as response]
 
             [buddy.auth :refer [authenticated? throw-unauthorized]]
             [buddy.auth.backends.session :refer [session-backend]]
+            [buddy.auth.backends.token :refer [jwe-backend]]
             [buddy.auth.middleware :refer [wrap-authentication wrap-authorization]]
+            [buddy.core.nonce :as nonce]
 
             [planwise.component.compound-handler :refer [compound-handler-component]]
             [planwise.component.auth :refer [auth-service]]
@@ -27,32 +31,67 @@
             [planwise.endpoint.auth :refer [auth-endpoint]]
             [planwise.endpoint.facilities :refer [facilities-endpoint]]
             [planwise.endpoint.projects :refer [projects-endpoint]]
-            [planwise.endpoint.routing :refer [routing-endpoint]]))
+            [planwise.endpoint.routing :refer [routing-endpoint]]
+            [planwise.endpoint.monitor :refer [monitor-endpoint]]))
 
 (timbre/refer-timbre)
 
-(def base-config
-  {:auth {:openid-identifier "https://login.instedd.org/openid"}
-   :api {:middleware [[wrap-json-params]
-                      [wrap-json-response]
-                      [wrap-defaults :defaults]
-                      [wrap-route-aliases :aliases]]
-         :defaults   (meta-merge api-defaults {})
-         :aliases    {}}
-   :app {:middleware [[wrap-not-found :not-found]
-                      [wrap-webjars]
-                      [wrap-defaults :defaults]
-                      [wrap-route-aliases :aliases]]
-         :not-found  (io/resource "planwise/errors/404.html")
-         :defaults   (meta-merge site-defaults
-                                 {:static {:resources "planwise/public"}
-                                  :session {:store (cookie-store)
-                                            :cookie-attrs {:max-age (* 24 3600)}
-                                            :cookie-name "planwise-session"}})
-         :aliases    {}}
+(defn api-unauthorized-handler
+  [request metadata]
+  (let [authenticated? (authenticated? request)
+        error-response {:error "Unauthorized"}
+        status (if authenticated? 403 401)]
+    (-> (response/response error-response)
+        (response/content-type "application/json")
+        (response/status status))))
 
-   :webapp {:handlers         ; Vector order matters, api handler is evaluated first
-            [:api :app]}})
+(defn app-unauthorized-handler
+  [request metadata]
+  (cond
+    (authenticated? request)
+    (let [error-response (io/resource "planwise/errors/403.html")]
+      (-> (compojure/render error-response request)
+          (response/content-type "text/html")
+          (response/status 403)))
+    :else
+    (let [current-url (:uri request)]
+      (response/redirect (format "/login?next=%s" current-url)))))
+
+
+(def jwe-options {:alg :a256kw :enc :a128gcm})
+(def jwe-secret (nonce/random-bytes 32))
+
+(def base-config
+  {:auth {:openid-identifier "https://login.instedd.org/openid"
+          :jwe-secret        jwe-secret
+          :jwe-options       jwe-options}
+   :api {:middleware   [[wrap-authorization :auth-backend]
+                        [wrap-authentication :auth-backend]
+                        [wrap-json-params]
+                        [wrap-json-response]
+                        [wrap-defaults :api-defaults]]
+         :auth-backend (jwe-backend {:secret jwe-secret
+                                     :options jwe-options
+                                     :unauthorized-handler api-unauthorized-handler})
+         :api-defaults (meta-merge api-defaults {})}
+   :app {:middleware   [[wrap-not-found :not-found]
+                        [wrap-webjars]
+                        [wrap-authorization :auth-backend]
+                        [wrap-authentication :auth-backend]
+                        [wrap-defaults :app-defaults]]
+         :not-found    (io/resource "planwise/errors/404.html")
+         :auth-backend (session-backend {:unauthorized-handler app-unauthorized-handler})
+         :app-defaults (meta-merge site-defaults
+                                   {:static {:resources "planwise/public"}
+                                    :session {:store (cookie-store)
+                                              :cookie-attrs {:max-age (* 24 3600)}
+                                              :cookie-name "planwise-session"}})}
+
+   :webapp {:middleware [[wrap-route-aliases :aliases]]
+            :aliases    {}
+
+            ; Vector order matters, api handler is evaluated first
+            :handlers   [:api :app]}})
 
 (defn new-system [config]
   (let [config (meta-merge base-config config)]
@@ -70,11 +109,13 @@
          :home-endpoint       (endpoint-component home-endpoint)
          :facilities-endpoint (endpoint-component facilities-endpoint)
          :projects-endpoint   (endpoint-component projects-endpoint)
-         :routing-endpoint    (endpoint-component routing-endpoint))
+         :routing-endpoint    (endpoint-component routing-endpoint)
+         :monitor-endpoint    (endpoint-component monitor-endpoint))
         (component/system-using
          {:http                {:app :webapp}
           :webapp              [:app :api]
-          :api                 [:facilities-endpoint
+          :api                 [:monitor-endpoint
+                                :facilities-endpoint
                                 :projects-endpoint
                                 :routing-endpoint]
           :app                 [:home-endpoint

--- a/src/planwise/system.clj
+++ b/src/planwise/system.clj
@@ -124,6 +124,7 @@
           :projects            [:db]
           :routing             [:db]
           :auth-endpoint       [:auth]
+          :home-endpoint       [:auth]
           :facilities-endpoint [:facilities]
           :projects-endpoint   [:projects]
           :routing-endpoint    [:routing]}))))

--- a/src/planwise/system.clj
+++ b/src/planwise/system.clj
@@ -62,9 +62,9 @@
 (def jwe-secret (nonce/random-bytes 32))
 
 (def base-config
-  {:auth {:openid-identifier "https://login.instedd.org/openid"
-          :jwe-secret        jwe-secret
-          :jwe-options       jwe-options}
+  {:auth {:guisso-url  "https://login.instedd.org/"
+          :jwe-secret  jwe-secret
+          :jwe-options jwe-options}
    :api {:middleware   [[wrap-authorization :auth-backend]
                         [wrap-authentication :auth-backend]
                         [wrap-json-params]

--- a/src/planwise/system.clj
+++ b/src/planwise/system.clj
@@ -27,6 +27,7 @@
             [planwise.component.facilities :refer [facilities-service]]
             [planwise.component.routing :refer [routing-service]]
             [planwise.component.projects :refer [projects-service]]
+            [planwise.component.users :refer [users-store]]
             [planwise.endpoint.home :refer [home-endpoint]]
             [planwise.endpoint.auth :refer [auth-endpoint]]
             [planwise.endpoint.facilities :refer [facilities-endpoint]]
@@ -105,6 +106,7 @@
          :facilities          (facilities-service)
          :projects            (projects-service)
          :routing             (routing-service)
+         :users-store         (users-store)
          :auth-endpoint       (endpoint-component auth-endpoint)
          :home-endpoint       (endpoint-component home-endpoint)
          :facilities-endpoint (endpoint-component facilities-endpoint)
@@ -123,6 +125,7 @@
           :facilities          [:db]
           :projects            [:db]
           :routing             [:db]
+          :users-store         [:db]
           :auth-endpoint       [:auth]
           :home-endpoint       [:auth]
           :facilities-endpoint [:facilities]

--- a/src/planwise/tasks/import_sites.clj
+++ b/src/planwise/tasks/import_sites.clj
@@ -57,7 +57,7 @@
        :db (hikaricp (:db config))
        :facilities (facilities/facilities-service))
       (component/system-using
-       :facilities [:db])))
+       {:facilities [:db]})))
 
 (defn -main [& args]
   (if-let [sites-file (first args)]

--- a/src/planwise/util/ring.clj
+++ b/src/planwise/util/ring.clj
@@ -1,0 +1,13 @@
+(ns planwise.util.ring
+  (:require [ring.util.request :refer [request-url]])
+  (:import [java.net URL MalformedURLException]))
+
+(defn- url? [^String s]
+  (try (URL. s) true
+       (catch MalformedURLException _ false)))
+
+(defn absolute-url [location request]
+  (if (url? location)
+    location
+    (let [url (URL. (request-url request))]
+      (str (URL. url location)))))

--- a/test/planwise/endpoint/home_test.clj
+++ b/test/planwise/endpoint/home_test.clj
@@ -14,10 +14,17 @@
                  "/projects/1/transport"
                  "/projects/1/scenarios"])
 
+(deftest home-endpoint-checks-login
+  (doseq [path home-paths]
+    (testing (str "path " path " throws 401")
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (-> (session handler)
+                       (visit path)))))))
+
 (deftest root-page-test
   (doseq [path home-paths]
     (testing (str "path " path " exists and renders CLJS application")
-     (-> (session handler)
-         (visit path)
-         (has (status? 200))
-         (has (some-text? "Loading Application"))))))
+      (-> (session handler)
+          (visit path :identity {:user "foo@example.com"})
+          (has (status? 200))
+          (has (some-text? "Loading Application"))))))

--- a/test/planwise/endpoint/home_test.clj
+++ b/test/planwise/endpoint/home_test.clj
@@ -1,11 +1,15 @@
 (ns planwise.endpoint.home-test
   (:require [planwise.endpoint.home :as home]
+            [buddy.core.nonce :as nonce]
             [clojure.test :refer :all]
             [kerodon.core :refer :all]
             [kerodon.test :refer :all]))
 
+(defn mock-auth-service []
+  {:jwe-secret (nonce/random-bytes 32)})
+
 (def handler
-  (home/home-endpoint {}))
+  (home/home-endpoint {:auth (mock-auth-service)}))
 
 (def home-paths ["/"
                  "/playground"


### PR DESCRIPTION
- Authenticate users using Guisso's OpenID
- For frontend endpoints, authorize using session cookies; for API requests, authorize using JWE tokens
- Create users table
- Implement a basic users store component
- Add users when they are authenticated and update last login time

Closes #33 