### PR TITLE
Update projects stats after importing facilities

### DIFF
--- a/resources/planwise/sql/facilities.sql
+++ b/resources/planwise/sql/facilities.sql
@@ -34,7 +34,7 @@ SELECT
   COUNT(*)
 FROM facilities
 WHERE ST_Contains(
-  (SELECT the_geom FROM regions WHERE id = :region LIMIT 1),
+  (SELECT the_geom FROM regions WHERE id = :region-id LIMIT 1),
   facilities.the_geom);
 
 -- :name facilities-with-isochrones :?

--- a/resources/planwise/sql/projects.sql
+++ b/resources/planwise/sql/projects.sql
@@ -1,4 +1,4 @@
--- :name insert-project! :<!
+-- :name insert-project! :<! :1
 INSERT INTO projects (goal, region_id, facilities_count)
     VALUES (:goal, :region-id, :facilities-count)
     RETURNING id;
@@ -12,3 +12,8 @@ ORDER BY id ASC;
 SELECT id, goal, region_id, facilities_count
 FROM projects
 WHERE id = :id;
+
+-- :name update-project* :! :n
+UPDATE projects
+SET facilities_count = :facilities-count
+WHERE projects.id = :project-id

--- a/src/planwise/component/facilities.clj
+++ b/src/planwise/component/facilities.clj
@@ -49,8 +49,10 @@
      {:criteria (facilities-criteria criteria)})))
 
 (defn count-facilities-in-region
-  [service {region :region}]
-  (count-facilities-in-region* (get-db service) {:region region}))
+  [service region-id]
+  (let [params {:region-id region-id}
+        result (count-facilities-in-region* (get-db service) params)]
+    (:count result)))
 
 (defn list-with-isochrones
   ([service]

--- a/src/planwise/system.clj
+++ b/src/planwise/system.clj
@@ -184,7 +184,8 @@
           :auth                [:users-store]
           :resmap              [:auth]
           :importer            [:resmap
-                                :facilities]
+                                :facilities
+                                :projects]
 
           ; Endpoints
           :auth-endpoint       [:auth]


### PR DESCRIPTION
- New function to update project stats (currently number of total
  facilities only)
- Update all project stats right after importing the facilities from
  Resourcemap and before processing each facility isochrones

Fixes #58, #61 and #62.