### PR TITLE
Generic client application config mechanism

### DIFF
--- a/src/planwise/client/api.cljs
+++ b/src/planwise/client/api.cljs
@@ -2,7 +2,8 @@
   (:require [ajax.core :refer [GET to-interceptor default-interceptors]]
             [re-frame.utils :as c]
             [re-frame.core :refer [dispatch]]
-            [clojure.string :as string]))
+            [clojure.string :as string]
+            [planwise.client.config :as config]))
 
 ;; Set default interceptor for adding CSRF token to all non-GET requests
 
@@ -19,7 +20,7 @@
 ;; Add interceptor to send JWT encrypted token authentication with all requests
 
 (def jwe-token
-  (atom (.-value (.getElementById js/document "__jwe-token"))))
+  (atom config/jwe-token))
 
 (def jwe-token-interceptor
   (to-interceptor {:name "JWE Token Interceptor"

--- a/src/planwise/client/config.cljs
+++ b/src/planwise/client/config.cljs
@@ -1,0 +1,13 @@
+(ns planwise.client.config)
+
+(def global-config
+  (aget js/window "_CONFIG"))
+
+(def resourcemap-url
+  (aget global-config "resourcemap-url"))
+
+(def jwe-token
+  (aget global-config "jwe-token"))
+
+(def user-email
+  (aget global-config "identity"))

--- a/src/planwise/client/datasets/views.cljs
+++ b/src/planwise/client/datasets/views.cljs
@@ -2,6 +2,7 @@
   (:require [re-frame.core :refer [subscribe dispatch]]
             [clojure.string :refer [capitalize]]
             [re-com.core :as rc]
+            [planwise.client.config :as config]
             [planwise.client.common :as common]))
 
 (defn initialised?
@@ -123,7 +124,7 @@
        [facilities-summary]
        [:div.resmap
         [:p "You can import facilities from a "
-         [:a {:href "http://resourcemap.instedd.org"} "Resourcemap"]
+         [:a {:href config/resourcemap-url :target "resmap"} "Resourcemap"]
          " collection. The collection to import needs to have the required fields "
          "(facility type, etc.) to be usable. Also only sites with a location will be imported."]
         (if (:authorised? @resourcemap)

--- a/src/planwise/client/views.cljs
+++ b/src/planwise/client/views.cljs
@@ -1,5 +1,6 @@
 (ns planwise.client.views
   (:require [re-frame.core :refer [subscribe dispatch]]
+            [planwise.client.config :as config]
             [planwise.client.routes :as routes]
             [planwise.client.common :as common]
             [planwise.client.playground.views :as playground]
@@ -13,7 +14,7 @@
    #_{:item :playground :href (routes/playground) :title "Playground"}])
 
 (def current-user-email
-  (atom (.-value (.getElementById js/document "__identity"))))
+  (atom config/user-email))
 
 (defn nav-bar []
   (let [current-page (subscribe [:current-page])]

--- a/src/planwise/system.clj
+++ b/src/planwise/system.clj
@@ -189,7 +189,8 @@
 
           ; Endpoints
           :auth-endpoint       [:auth]
-          :home-endpoint       [:auth]
+          :home-endpoint       [:auth
+                                :resmap]
           :facilities-endpoint [:facilities]
           :regions-endpoint    [:regions]
           :projects-endpoint   [:projects]


### PR DESCRIPTION
- Add a generic way for the server to communicate global/per request
  configuration to the client application.
- Use the config mechanism to retrieve the JWE token, user email and
  Resourcemap URL.

Closes #67.