### PR TITLE
Add global tick event every second

### DIFF
--- a/src/planwise/client/core.cljs
+++ b/src/planwise/client/core.cljs
@@ -28,10 +28,13 @@
 (defn install-ticker! []
   (let [time (atom 0)
         interval 1000]
-    (.setInterval
-      js/window
-      #(dispatch [:tick (swap! time + interval)])
-      interval)))
+    (letfn [(timeout-fn [] (.setTimeout
+                            js/window
+                            #(do
+                              (dispatch [:tick (swap! time + interval)])
+                              (timeout-fn))
+                            interval))]
+      (timeout-fn))))
 
 (defn- ^:export main []
   (dispatch-sync [:initialise-db])

--- a/src/planwise/client/core.cljs
+++ b/src/planwise/client/core.cljs
@@ -25,6 +25,14 @@
                        (let [message (.-data e)]
                          (dispatch [:message-posted message])))))
 
+(defn install-ticker! []
+  (let [time (atom 0)
+        interval 1000]
+    (.setInterval
+      js/window
+      #(dispatch [:tick (swap! time + interval)])
+      interval)))
+
 (defn- ^:export main []
   (dispatch-sync [:initialise-db])
   (accountant/configure-navigation!
@@ -36,4 +44,5 @@
        (secretary/locate-route path))})
   (accountant/dispatch-current!)
   (install-message-handler!)
+  (install-ticker!)
   (mount-root))

--- a/src/planwise/client/handlers.cljs
+++ b/src/planwise/client/handlers.cljs
@@ -57,3 +57,10 @@
      "authenticated" (dispatch [:datasets/reload-info])
      (c/warn "Invalid message received " message))
    db))
+
+(register-handler
+ :tick
+ (fn [db [_ time]]
+   (when (= 0 (mod time 3000))
+     (dispatch [:datasets/update-import-status]))
+   db))


### PR DESCRIPTION
Attach datasets/update-import-status to every 3 seconds, and request state from API when state is importing.

Fixes #60.