### PR TITLE
Implement project ownership

### DIFF
--- a/resources/migrations/018-add_owner_user_to_projects.down.sql
+++ b/resources/migrations/018-add_owner_user_to_projects.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE projects DROP COLUMN owner_id;

--- a/resources/migrations/018-add_owner_user_to_projects.up.sql
+++ b/resources/migrations/018-add_owner_user_to_projects.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE projects ADD COLUMN owner_id BIGINT REFERENCES users(id);

--- a/resources/planwise/sql/projects.sql
+++ b/resources/planwise/sql/projects.sql
@@ -1,18 +1,27 @@
 -- :name insert-project! :<! :1
-INSERT INTO projects (goal, region_id, stats)
-    VALUES (:goal, :region-id, :stats)
+INSERT INTO projects (goal, region_id, stats, owner_id)
+    VALUES (:goal, :region-id, :stats, :owner-id)
     RETURNING id;
 
 -- :name select-projects :?
 SELECT
-  projects.id, projects.goal, projects.region_id, projects.stats,
-  regions.name AS region_name
+  projects.id, projects.goal, projects.region_id AS "region-id", projects.stats,
+  regions.name AS "region-name", owner_id AS "owner-id"
 FROM projects
 INNER JOIN regions ON projects.region_id = regions.id
 ORDER BY projects.id ASC;
 
+-- :name select-projects-for-user :?
+SELECT
+  projects.id, projects.goal, projects.region_id AS "region-id", projects.stats,
+  regions.name AS "region-name", owner_id AS "owner-id"
+FROM projects
+INNER JOIN regions ON projects.region_id = regions.id
+WHERE projects.owner_id = :user-id
+ORDER BY projects.id ASC;
+
 -- :name select-project :? :1
-SELECT id, goal, region_id, stats, filters
+SELECT id, goal, region_id AS "region-id", stats, filters, owner_id AS "owner-id"
 FROM projects
 WHERE id = :id;
 

--- a/resources/planwise/sql/users.sql
+++ b/resources/planwise/sql/users.sql
@@ -1,16 +1,16 @@
 -- :name select-user :? :1
-SELECT id, email, full_name, last_login
+SELECT id, email, full_name AS "full-name", last_login AS "last-login"
 FROM users
 WHERE id = :id;
 
 -- :name select-user-by-email :? :1
-SELECT id, email, full_name, last_login
+SELECT id, email, full_name AS "full-name", last_login AS "last-login"
 FROM users
 WHERE email = :email;
 
 -- :name create-user! :<!
 INSERT INTO users (email, full_name, created_at)
-       VALUES(:email, :full_name, 'now')
+       VALUES (:email, :full-name, 'now')
        RETURNING id;
 
 -- :name update-last-login! :! :n
@@ -25,7 +25,13 @@ INSERT INTO tokens (user_id, scope, token, refresh_token, expires)
        RETURNING id;
 
 -- :name find-latest-user-token :? :1
-SELECT t.id, t.user_id, t.scope, t.token, t.refresh_token, t.expires
+SELECT
+  t.id,
+  t.user_id AS "user-id",
+  t.scope,
+  t.token,
+  t.refresh_token AS "refresh-token",
+  t.expires
 FROM tokens t
 INNER JOIN users u ON u.id = t.user_id
 WHERE u.email = :email AND t.scope = :scope

--- a/src/planwise/auth/ident.clj
+++ b/src/planwise/auth/ident.clj
@@ -1,0 +1,18 @@
+(ns planwise.auth.ident)
+
+;; User identity related functions
+;; The user identity is the user information carried around in the session
+;; cookies and the JWE tokens.
+
+(defn user->ident
+  [user]
+  {:user-email (:email user)
+   :user-id    (:id user)})
+
+(defn user-email
+  [user-ident]
+  (:user-email user-ident))
+
+(defn user-id
+  [user-ident]
+  (:user-id user-ident))

--- a/src/planwise/boundary/projects.clj
+++ b/src/planwise/boundary/projects.clj
@@ -8,8 +8,8 @@
     "Creates a project given a map of its attributes. Returns a map with the
     database generated id.")
 
-  (list-projects [this]
-    "Returns all projects in the database.")
+  (list-projects-for-user [this user-id]
+    "Returns projects accessible by the user.")
 
   (get-project [this id]
     "Return project with the given ID.")
@@ -28,11 +28,21 @@
   planwise.component.projects.ProjectsService
   (create-project [service project]
     (service/create-project service project))
-  (list-projects [service]
-    (service/list-projects service))
+  (list-projects-for-user [service user-id]
+    (service/list-projects-for-user service user-id))
   (get-project [service id]
     (service/get-project service id))
   (update-project [service project]
     (service/update-project service project))
   (delete-project [service id]
     (service/delete-project service id)))
+
+;; Additional utility functions
+
+(defn accessible-by?
+  [project user-id]
+  (service/accessible-by? project user-id))
+
+(defn owned-by?
+  [project user-id]
+  (service/owned-by? project user-id))

--- a/src/planwise/component/projects.clj
+++ b/src/planwise/component/projects.clj
@@ -21,8 +21,6 @@
   de application"
   [record]
   (-> record
-      (set/rename-keys {:region_id :region-id
-                        :region_name :region-name})
       (update :stats edn/read-string)
       (update :filters edn/read-string)))
 
@@ -49,8 +47,13 @@
 ;; ----------------------------------------------------------------------
 ;; Service functions
 
-(defn list-projects [service]
+(defn list-projects
+  [service]
   (->> (select-projects (get-db service))
+       (map db->project)))
+
+(defn list-projects-for-user [service user-id]
+  (->> (select-projects-for-user (get-db service) {:user-id user-id})
        (map db->project)))
 
 (defn get-project [service id]
@@ -118,3 +121,13 @@
 
 (defn delete-project [service id]
   (pos? (delete-project* (get-db service) {:id id})))
+
+
+(defn owned-by?
+  [project user-id]
+  (= user-id (:owner-id project)))
+
+(defn accessible-by?
+  [project user-id]
+  (or (owned-by? project user-id)))
+

--- a/src/planwise/component/resmap.clj
+++ b/src/planwise/component/resmap.clj
@@ -4,6 +4,7 @@
             [clojure.string :as str]
             [cheshire.core :as json]
             [clj-http.client :as http]
+            [planwise.auth.ident :as ident]
             [planwise.component.auth :as auth])
   (:import [java.net URL]))
 
@@ -80,7 +81,7 @@
   (let [scope (auth-scope service)
         auth (:auth service)
         token (auth/find-auth-token auth scope user-ident)]
-    (info "Retrieving Resourcemap collections for user" (auth/get-email user-ident))
+    (info "Retrieving Resourcemap collections for user" (ident/user-email user-ident))
     (list-collections service token)))
 
 (defn list-collection-fields
@@ -89,7 +90,7 @@
         auth (:auth service)
         token (auth/find-auth-token auth scope user-ident)]
     (info "Retrieving Resourcemap fields information for collection"
-          coll-id "for user" (auth/get-email user-ident))
+          coll-id "for user" (ident/user-email user-ident))
     (get-collection-fields service token coll-id)))
 
 (defn authorised?

--- a/src/planwise/component/users.clj
+++ b/src/planwise/component/users.clj
@@ -2,6 +2,7 @@
   (:require [com.stuartsierra.component :as component]
             [taoensso.timbre :as timbre]
             [clojure.java.jdbc :as jdbc]
+            [clojure.set :as set]
             [clj-time.jdbc]
             [hugsql.core :as hugsql]))
 
@@ -40,7 +41,7 @@
   (jdbc/with-db-transaction [tx (get-db service)]
     (let [user (select-user-by-email tx {:email email})]
       (if-not user
-        (let [user-id (-> (create-user! tx {:email email, :full_name nil})
+        (let [user-id (-> (create-user! tx {:email email, :full-name nil})
                           (first)
                           (:id))]
           (select-user tx {:id user-id}))
@@ -60,9 +61,7 @@
   [service scope email]
   (let [token (find-latest-user-token (get-db service) {:email email :scope scope})]
     (when token
-      {:expires (:expires token)
-       :refresh-token (:refresh_token token)
-       :token (:token token)})))
+      (select-keys token [:expires :refresh-token :token]))))
 
 (defn save-token-for-scope!
   [service scope email token]

--- a/src/planwise/endpoint/auth.clj
+++ b/src/planwise/endpoint/auth.clj
@@ -5,6 +5,7 @@
             [hiccup.page :refer [html5]]
             [clojure.string :as string]
             [buddy.auth :refer [throw-unauthorized authenticated?]]
+            [planwise.util.ring :as util]
             [planwise.component.auth :as auth]))
 
 (def logout-page
@@ -30,16 +31,17 @@
    (GET "/identity" req
      (if-not (authenticated? req)
        (throw-unauthorized)
-       (let [id (-> req :identity :user)]
+       (let [ident (util/request-ident req)]
         (html5
          [:body
-          [:p (str "Current identity: " id)]
+          [:p (str "Current identity: " (util/request-user-email req)
+                   " id=" (util/request-user-id req))]
           [:p
            "API Token:"
            [:br]
            [:code {:style {:white-space "normal"
                            :word-wrap "break-word"}}
-            (auth/create-jwe-token service id)]]
+            (auth/create-jwe-token service ident)]]
           [:p
            [:a {:href "/logout"} "Logout"]]]))))
 

--- a/src/planwise/endpoint/home.clj
+++ b/src/planwise/endpoint/home.clj
@@ -1,11 +1,12 @@
 (ns planwise.endpoint.home
   (:require [compojure.core :refer :all]
             [ring.util.anti-forgery :refer [anti-forgery-field]]
-            [buddy.auth :refer [authenticated? throw-unauthorized]]
-            [planwise.component.auth :refer [create-jwe-token]]
             [cheshire.core :as json]
             [hiccup.form :refer [hidden-field]]
-            [hiccup.page :refer [include-js include-css html5]]))
+            [hiccup.page :refer [include-js include-css html5]]
+            [buddy.auth :refer [authenticated? throw-unauthorized]]
+            [planwise.util.ring :as util]
+            [planwise.component.auth :refer [create-jwe-token]]))
 
 (def mount-target
   [:div#app
@@ -29,8 +30,9 @@
   [{:keys [auth resmap request maps globals]}]
   (let [resmap-url (:url resmap)
         demo-tile-url (:demo-tile-url maps)
-        email (-> request :identity :user)
-        token (create-jwe-token auth email)
+        ident (util/request-ident request)
+        email (util/request-user-email request)
+        token (create-jwe-token auth ident)
         app-version (or (:app-version globals) "unspecified")
         config {:resourcemap-url resmap-url
                 :identity email

--- a/src/planwise/endpoint/monitor.clj
+++ b/src/planwise/endpoint/monitor.clj
@@ -2,11 +2,13 @@
   (:require [compojure.core :refer :all]
             [ring.util.response :refer [response]]
             [buddy.auth :refer [authenticated?]]
-            [buddy.auth.accessrules :refer [restrict]]))
+            [buddy.auth.accessrules :refer [restrict]]
+            [planwise.util.ring :as util]))
 
 (defn whoami-handler [request]
-  (let [id (-> request :identity :user)]
-    (response {:email id})))
+  (let [email (util/request-user-email request)
+        user-id (util/request-user-id request)]
+    (response {:id user-id :email email})))
 
 (defn monitor-endpoint [system]
   (context "/api" []

--- a/src/planwise/endpoint/projects.clj
+++ b/src/planwise/endpoint/projects.clj
@@ -4,6 +4,7 @@
             [clojure.data.json :as json]
             [buddy.auth :refer [authenticated?]]
             [buddy.auth.accessrules :refer [restrict]]
+            [planwise.util.ring :as util]
             [planwise.boundary.projects :as projects]
             [planwise.boundary.facilities :as facilities]
             [clojure.walk :refer [keywordize-keys]]
@@ -28,32 +29,47 @@
 (defn- endpoint-routes
   [{service :projects facilities :facilities}]
   (routes
-   (GET "/" []
-     (let [projects (projects/list-projects service)]
+   (GET "/" request
+     (let [user-id (util/request-user-id request)
+           projects (projects/list-projects-for-user service user-id)]
        (response projects)))
 
-   (GET "/:id" [id with]
-     (if-let [project (projects/get-project service (Integer. id))]
-       (response (assoc-extra-data (keyword with) project facilities))
-       (not-found {:error "Project not found"})))
-
-   (PUT "/:id" [id filters with]
-     (let [id (Integer. id)
-           filters (keywordize-keys filters)]
-       (if-let [project (projects/update-project service {:id id :filters filters})]
+   (GET "/:id" [id with :as request]
+     (let [user-id (util/request-user-id request)
+           project (projects/get-project service (Integer. id))]
+       (if (projects/accessible-by? project user-id)
          (response (assoc-extra-data (keyword with) project facilities))
-         (-> (response {:status "failure"})
-             (status 400)))))
+         (not-found {:error "Project not found"}))))
 
-   (POST "/" [goal region-id]
+   (PUT "/:id" [id filters with :as request]
+     (let [id (Integer. id)
+           filters (keywordize-keys filters)
+           user-id (util/request-user-id request)
+           project (projects/get-project service id)]
+       (if (projects/owned-by? project user-id)
+         (if-let [project (projects/update-project service {:id id :filters filters})]
+           (response (assoc-extra-data (keyword with) project facilities))
+           (-> (response {:status "failure"})
+               (status 400)))
+         (not-found {:error "Project not found"}))))
+
+   (POST "/" [goal region-id :as request]
      (let [goal (str/trim goal)
-           region-id (Integer. region-id)]
-       (response (projects/create-project service {:goal goal, :region-id region-id}))))
+           region-id (Integer. region-id)
+           user-id (util/request-user-id request)
+           project-templ {:goal goal
+                          :region-id region-id
+                          :owner-id user-id}]
+       (response (projects/create-project service project-templ))))
 
-   (DELETE "/:id" [id]
-     (if-let [project (projects/delete-project service (Integer. id))]
-       (response {:deleted id})
-       (not-found {:error "Project not found"})))))
+   (DELETE "/:id" [id :as request]
+     (let [id (Integer. id)
+           user-id (util/request-user-id request)
+           project (projects/get-project service id)]
+       (if (and (projects/owned-by? project user-id)
+                (projects/delete-project service id))
+         (response {:deleted id})
+         (not-found {:error "Project not found"}))))))
 
 (defn projects-endpoint [endpoint]
   (context "/api/projects" []

--- a/src/planwise/util/ring.clj
+++ b/src/planwise/util/ring.clj
@@ -1,5 +1,6 @@
 (ns planwise.util.ring
-  (:require [ring.util.request :refer [request-url]])
+  (:require [ring.util.request :refer [request-url]]
+            [planwise.auth.ident :as ident])
   (:import [java.net URL MalformedURLException]))
 
 (defn- url? [^String s]
@@ -11,3 +12,17 @@
     location
     (let [url (URL. (request-url request))]
       (str (URL. url location)))))
+
+(defn request-ident
+  [request]
+  (:identity request))
+
+(defn request-user-id
+  [request]
+  (-> (request-ident request)
+      ident/user-id))
+
+(defn request-user-email
+  [request]
+  (-> (request-ident request)
+      ident/user-email))

--- a/test/planwise/component/users_test.clj
+++ b/test/planwise/component/users_test.clj
@@ -1,0 +1,90 @@
+(ns planwise.component.users-test
+  (:require [clojure.test :refer :all]
+            [clj-time.core :as time]
+            [clojure.java.jdbc :as jdbc]
+            [com.stuartsierra.component :as component]
+            [planwise.component.users :as users]
+            [planwise.test-system :refer [test-system with-system]]))
+
+(defn execute-sql
+  [system sql]
+  (jdbc/execute! (get-in system [:db :spec]) sql))
+
+(def test-email "user@example.com")
+(def test-full-name "John Doe")
+(def test-user-id 1)
+(def test-scope "resourcemap.instedd.org")
+
+(defn fixture-data
+  []
+  [[:users
+    [{:id test-user-id :email test-email :full_name test-full-name
+      :created_at (time/now)}]]
+   [:tokens
+    [{:user_id test-user-id :scope test-scope :token "EXPIRED-TOKEN-1"
+      :refresh_token "REFRESH-TOKEN-1" :expires (time/ago (time/minutes 5))}
+     {:user_id test-user-id :scope test-scope :token "TOKEN-2"
+      :refresh_token "REFRESH-TOKEN-2" :expires (time/ago (time/minutes 1))}]]])
+
+(defn system
+  []
+  (into
+   (test-system {:fixtures {:data (fixture-data)}})
+   {:users-store (component/using (users/users-store) [:db])}))
+
+(deftest find-user-test
+  (with-system (system)
+    (let [store (:users-store system)
+          user (users/find-user store test-user-id)]
+      (is (some? user))
+      (is (= test-user-id (:id user)))
+      (is (= test-email (:email user)))
+      (is (= test-full-name (:full-name user)))
+      (is (nil? (:last-login user))))))
+
+(deftest find-user-or-create-test
+  (with-system (system)
+    (let [store (:users-store system)]
+      (let [existing (users/find-or-create-user-by-email store test-email)]
+        (is (some? existing))
+        (is (= test-user-id (:id existing)))
+        (is (= test-full-name (:full-name existing))))
+      (let [_ (execute-sql system "ALTER SEQUENCE users_id_seq RESTART WITH 2")
+            new-user (users/find-or-create-user-by-email store "other@instedd.org")]
+        (is (some? new-user))
+        (is (= 2 (:id new-user)))
+        (is (= "other@instedd.org" (:email new-user)))
+        (is (nil? (:last-login new-user)))))))
+
+(deftest update-last-login-test
+  (with-system (system)
+    (let [store (:users-store system)
+          start-time (time/now)
+          user-before (users/find-user store test-user-id)
+          result (users/update-user-last-login! store test-user-id)
+          user-after (users/find-user store test-user-id)]
+      (is (nil? (:last-login user-before)))
+      (is (true? result))
+      (is (some? (:last-login user-after)))
+      (is (time/after? (:last-login user-after) start-time))
+      (is (time/before? (:last-login user-after) (time/now))))))
+
+(deftest find-latest-token-test
+  (with-system (system)
+    (let [store (:users-store system)
+          email test-email
+          token (users/find-latest-token-for-scope store test-scope email)]
+      (is (= "TOKEN-2" (:token token)))
+      (is (= "REFRESH-TOKEN-2" (:refresh-token token)))
+      (is (time/after? (:expires token) (time/ago (time/minutes 2)))))))
+
+(deftest save-token-test
+  (with-system (system)
+    (let [store (:users-store system)
+          scope test-scope
+          new-token {:token "SAVE-TOKEN"
+                     :refresh-token "SAVE-REFRESH"
+                     :expires (time/from-now (time/minutes 5))}
+          _ (users/save-token-for-scope! store test-scope test-email new-token)
+          token (users/find-latest-token-for-scope store test-scope test-email)]
+      (is (= new-token token)))))


### PR DESCRIPTION
- Add owner_id column to projects.
- Add user-id in the user identity that is transferred in the session and auth tokens.
- Projects listing will return projects accessible for the user (currently only the ones owned by her).
- The other operations will return a 404 when the user has no permission to access the project.

Closes #129 
