### PR TITLE
Importer refactor

### DIFF
--- a/dev/dev.clj
+++ b/dev/dev.clj
@@ -34,8 +34,7 @@
    :paths {:bin "cpp/"
            :scripts "scripts/"
            :data "data/"}
-   :maps {:mapserver-url "http://localhost:5002/mapcache?"
-          :facilities-capacity 2000000}
+   :maps {:facilities-capacity 2000000}
    :figwheel
    {:css-dirs ["resources/planwise/public/css"
                "target/sass-repl"]

--- a/project.clj
+++ b/project.clj
@@ -43,6 +43,7 @@
                  [hiccup "1.0.5"]
                  [cheshire "5.6.3"]
                  [clj-time "0.12.0"]
+                 [reduce-fsm "0.1.4"]
 
                  ; Client infrastructure
                  [reagent "0.5.1"

--- a/resources/planwise/sql/facilities.sql
+++ b/resources/planwise/sql/facilities.sql
@@ -1,7 +1,7 @@
 -- :name insert-facility! :! :n
 INSERT INTO facilities
     (id, name, lat, lon, type_id, the_geom)
-    VALUES (:id, :name, :lat, :lon, :type_id, ST_SetSRID(ST_MakePoint(:lon, :lat), 4326));
+    VALUES (:id, :name, :lat, :lon, :type-id, ST_SetSRID(ST_MakePoint(:lon, :lat), 4326));
 
 -- :name delete-facilities! :!
 DELETE FROM facilities;

--- a/src/planwise/client/datasets/db.cljs
+++ b/src/planwise/client/datasets/db.cljs
@@ -1,4 +1,26 @@
-(ns planwise.client.datasets.db)
+(ns planwise.client.datasets.db
+  (:require [schema.core :as s :include-macros true]))
+
+(s/defschema ServerStatus
+  {:status                    (s/enum :ready :done :importing :cancelling :unknown)
+   (s/optional-key :state)    s/Keyword
+   (s/optional-key :result)   s/Any
+   (s/optional-key :progress) s/Any})
+
+(s/defschema Datasets
+  "Datasets related portion of the client database"
+  {:state          (s/enum nil
+                           :initialising
+                           :ready
+                           :import-requested
+                           :importing
+                           :cancel-requested
+                           :cancelling)
+   :server-status  (s/maybe ServerStatus)
+   :facility-count (s/maybe s/Int)
+   :resourcemap    {:authorised? (s/maybe s/Bool)
+                    :collections s/Any}
+   :selected       s/Any})
 
 (def empty-datasets-selected
   {:collection nil
@@ -11,17 +33,78 @@
                                         ; Field selected for mapping facility type
 
 (def initial-db
-  {:state nil
+  {:state          nil
                                         ; :initialising/nil :ready :importing
-   :cancel-requested false
-   :raw-status       nil
-   :facility-count   nil
+   :server-status  nil
+                                        ; Importer status as reported by the server
+   :facility-count nil
                                         ; Count of available facilities
-   :resourcemap {
-                 :authorised?  nil
+   :resourcemap    {:authorised?  nil
                                         ; Whether the user has authorised for
                                         ; Resourcemap access
-                 :collections  nil}
+                    :collections  nil}
                                         ; Resourcemap collections
 
    :selected empty-datasets-selected})
+
+
+(defn initialised?
+  [state]
+  (and (not= :initialising state)
+       (not (nil? state))))
+
+(defn importing?
+  [state]
+  (or (= :importing state)
+      (= :import-requested state)
+      (= :cancelling state)
+      (= :cancel-requested state)))
+
+(defn cancelling?
+  [state]
+  (or (= :cancelling state)
+      (= :cancel-requested state)))
+
+(defn request-pending?
+  [state]
+  (or (= :cancel-requested state)
+      (= :import-requested state)))
+
+(defn server-status->string
+  [server-status]
+  (case (:status server-status)
+    :ready
+    "Ready"
+
+    :done
+    (case (:result server-status)
+      :success "Import successful"
+      :cancelled "Import cancelled"
+      :unexpected-event "Fatal error: unexpected event received"
+      :import-types-failed "Error: failed to import facility types"
+      :import-sites-failed "Error: failed to import sites from Resourcemap"
+      :update-projects-failed "Error: failed to update projects")
+
+    :importing
+    (let [progress (:progress server-status)]
+      ;; TODO: add progress to the returned string
+      (case (:state server-status)
+        (:start :importing-types) "Importing facility types"
+        (:request-sites :importing-sites) "Importing sites from Resourcemap"
+        (:processing-facilities) "Pre-processing facilities"
+        (:update-projects :updating-projects) "Updating projects"
+        "Importing..."))
+
+    :cancelling
+    "Cancelling..."
+
+    :unknown
+    "Unknown server status"))
+
+(defn server-status->state
+  [{status :status}]
+  (case status
+    (:ready :done) :ready
+    :importing     :importing
+    :cancelling    :cancelling
+    :unknown       :ready))

--- a/src/planwise/client/datasets/subs.cljs
+++ b/src/planwise/client/datasets/subs.cljs
@@ -8,11 +8,6 @@
    (reaction (get-in @db [:datasets :state]))))
 
 (register-sub
- :datasets/cancel-requested
- (fn [db [_]]
-   (reaction (get-in @db [:datasets :cancel-requested]))))
-
-(register-sub
  :datasets/facility-count
  (fn [db [_]]
    (reaction (get-in @db [:datasets :facility-count]))))
@@ -28,6 +23,6 @@
    (reaction (get-in @db [:datasets :selected]))))
 
 (register-sub
- :datasets/raw-status
+ :datasets/server-status
  (fn [db [_]]
-   (reaction (get-in @db [:datasets :raw-status]))))
+   (reaction (get-in @db [:datasets :server-status]))))

--- a/src/planwise/client/datasets/views.cljs
+++ b/src/planwise/client/datasets/views.cljs
@@ -89,8 +89,18 @@
         [:div.dataset-header
          [:h2 "Facilities"]
          (if-not importing?
-           [:p "There are " [:b (utils/pluralize @facility-count "facility" "facilities")] " in the system."]
-           (let [step (db/server-status->string @server-status)]
+           (let [last-result (db/last-import-result @server-status)]
+             [:div
+              [:p
+               "There are "
+               [:b (utils/pluralize @facility-count "facility" "facilities")]
+               " in the system."]
+              (when (some? last-result)
+                [:div.bottom-right
+                 [:p "Last import: " last-result]])])
+           (let [step (if (= :import-requested @state)
+                        "Starting"
+                        (db/server-status->string @server-status))]
              [:div
               [:h3
                "Import in progress: "

--- a/src/planwise/client/datasets/views.cljs
+++ b/src/planwise/client/datasets/views.cljs
@@ -4,15 +4,8 @@
             [re-com.core :as rc]
             [planwise.client.config :as config]
             [planwise.client.components.common :as common]
+            [planwise.client.datasets.db :as db]
             [planwise.client.utils :as utils]))
-
-(defn initialised?
-  [state]
-  (and (not= :initialising state) (not (nil? state))))
-
-(defn importing?
-  [state]
-  (= :importing state))
 
 (defn open-auth-popup []
   (.open js/window
@@ -35,7 +28,7 @@
       (let [valid? (:valid? @selected)
             fields (:fields @selected)
             type-field (:type-field @selected)
-            importing? (importing? @state)
+            importing? (db/importing? @state)
             can-import? (and (not importing?) valid? (some? type-field))]
         [:div.import-settings
          (if (nil? fields)
@@ -75,7 +68,7 @@
         state (subscribe [:datasets/state])]
     (fn [collections]
       (let [selected-coll (:collection @selected)
-            importing? (importing? @state)]
+            importing? (db/importing? @state)]
         [:ul.collections
          (for [coll collections]
            (let [coll-id (:id coll)
@@ -89,21 +82,19 @@
 (defn facilities-summary []
   (let [facility-count (subscribe [:datasets/facility-count])
         state (subscribe [:datasets/state])
-        cancel-requested (subscribe [:datasets/cancel-requested])
-        raw-status (subscribe [:datasets/raw-status])]
+        server-status (subscribe [:datasets/server-status])]
     (fn []
-      (let [importing? (importing? @state)
-            cancelling? @cancel-requested]
+      (let [importing? (db/importing? @state)
+            cancelling? (db/cancelling? @state)]
         [:div.dataset-header
          [:h2 "Facilities"]
          (if-not importing?
            [:p "There are " [:b (utils/pluralize @facility-count "facility" "facilities")] " in the system."]
-           (let [[_ step progress] @raw-status
-                 step (or step "Importing collection")]
+           (let [step (db/server-status->string @server-status)]
              [:div
               [:h3
                "Import in progress: "
-               [:b (str (capitalize (name step)) " " progress)]]
+               [:b step]]
               [:div.bottom-right
                [:button.danger
                 {:type :button
@@ -115,7 +106,7 @@
   (let [resourcemap (subscribe [:datasets/resourcemap])
         state (subscribe [:datasets/state])]
     (fn []
-      (let [importing? (importing? @state)]
+      (let [importing? (db/importing? @state)]
         [:div {:class (when importing? "disabled")}
          [:h3 "Available Resourcemap collections "
           (when-not importing?
@@ -146,7 +137,7 @@
 (defn datasets-page []
   (let [state (subscribe [:datasets/state])]
     (fn []
-      (let [initialised? (initialised? @state)]
+      (let [initialised? (db/initialised? @state)]
         [:article.datasets
          (if initialised?
            [datasets-view]

--- a/src/planwise/client/utils.cljs
+++ b/src/planwise/client/utils.cljs
@@ -42,7 +42,7 @@
   ([x]
    (format-percentage x 0))
   ([x decimals]
-   (let [x (min x (max 1 x))
+   (let [x (min 1 (max 0 x))
          percentage (* 100 x)
          format-string (str "%." decimals "f%%")]
      (gstring/format format-string percentage))))

--- a/src/planwise/client/utils.cljs
+++ b/src/planwise/client/utils.cljs
@@ -1,6 +1,8 @@
 (ns planwise.client.utils
   (:require-macros [cljs.core.async.macros :refer [go]])
-  (:require [cljs.core.async :as async :refer [chan >! <! put!]]))
+  (:require [cljs.core.async :as async :refer [chan >! <! put!]]
+            [goog.string :as gstring]
+            [goog.string.format]))
 
 ;; Debounce functions
 
@@ -35,3 +37,12 @@
   ([count singular plural]
    (let [noun (if (= 1 count) singular plural)]
      (str count " " noun))))
+
+(defn format-percentage
+  ([x]
+   (format-percentage x 0))
+  ([x decimals]
+   (let [x (min x (max 1 x))
+         percentage (* 100 x)
+         format-string (str "%." decimals "f%%")]
+     (gstring/format format-string percentage))))

--- a/src/planwise/component/auth.clj
+++ b/src/planwise/component/auth.clj
@@ -168,10 +168,10 @@
 (defn find-auth-token
   [{:keys [users-store] :as service} scope user-ident]
   (let [email (ident/user-email user-ident)
-        _     (info "Looking for token for" email "on scope" scope)
+        _     (debug "Looking for token for" email "on scope" scope)
         token (users/find-latest-token-for-scope users-store scope email)]
     (if (and token (token-expired? token))
-      (do (info "Found token but it expired, refreshing token")
+      (do (info (str "Token for " email " (" scope ") found but it expired. Refreshing."))
           (let [new-token (oauth2-refresh-token service (:refresh-token token))]
             (when new-token
               (save-auth-token! service scope user-ident new-token))))

--- a/src/planwise/component/facilities.clj
+++ b/src/planwise/component/facilities.clj
@@ -122,12 +122,13 @@
 
 (defn preprocess-isochrones
   [service facility-id]
-  (calculate-facility-isochrones! (get-db service)
-                                  {:id facility-id
-                                   :method "alpha-shape"
-                                   :start 30
-                                   :end 180
-                                   :step 15})
+  (let [result (calculate-facility-isochrones! (get-db service)
+                                               {:id facility-id
+                                                :method "alpha-shape"
+                                                :start 30
+                                                :end 180
+                                                :step 15})]
+    (debug (str "Facility " facility-id " isochrone processed with result: " (vec result))))
   (when (get-in service [:config :raster-isochrones])
     (calculate-isochrones-population! service facility-id)
     (raster-isochrones! service facility-id)))

--- a/src/planwise/component/importer.clj
+++ b/src/planwise/component/importer.clj
@@ -82,12 +82,13 @@
   [{:keys [resmap facilities]} user coll-id type-field page]
   (info (str "Requesting page " page " of collection " coll-id " from Resourcemap"))
   (let [data (resmap/get-collection-sites resmap user coll-id {:page page})
-        sites (:sites data)]
+        sites (:sites data)
+        total-pages (:totalPages data)]
     (when (seq sites)
       (let [new-facilities (sites->facilities sites type-field)]
         (info "Inserting" (count new-facilities) "facilities from page" page "of collection" coll-id)
         (facilities/insert-facilities! facilities new-facilities)
-        [:continue (map :id new-facilities)]))))
+        [:continue (map :id new-facilities) total-pages]))))
 
 (defn process-facilities
   [facilities facility-ids]

--- a/src/planwise/component/importer.clj
+++ b/src/planwise/component/importer.clj
@@ -2,41 +2,33 @@
   (:require [com.stuartsierra.component :as component]
             [taoensso.timbre :as timbre]
             [clojure.set :refer [rename-keys]]
-            [clojure.core.async :refer [chan put! poll! offer! <! >! go go-loop]]
+            [planwise.model.import-job :as import-job]
             [planwise.component.resmap :as resmap]
             [planwise.component.projects :as projects]
-            [planwise.component.facilities :as facilities]))
+            [planwise.component.facilities :as facilities]
+            [planwise.component.taskmaster :as taskmaster]))
 
 (timbre/refer-timbre)
 
+
+;; ----------------------------------------------------------------------------
+;; Import job task implementations
+
 ;; Field definition from resmap service
-;; {:id "15890", :name "Type", :code "type", :kind "select_one", :config {:options [{:id 1, :code "hospital", :label "Hospital"} {:id 2, :code "health center", :label "Health Center"} {:id 3, :code "dispensary", :label "Dispensary"}], :next_id 4}}
-
-(defn import-cancelled?
-  [{:keys [control-channel status]}]
-  (if (and (seq? @status) (= (first @status) :cancelling))
-    true
-    (when-let [msg (poll! control-channel)]
-      (cond
-        (= :cancel (first msg))
-        (do
-          (info "Cancelling import process upon request")
-          (swap! status (constantly :cancelling))
-          true)
-
-        (= :quit (first msg))
-        (do
-          (info "Cancelling import process (service is quitting)")
-          (swap! status (constantly :cancelling))
-          (offer! control-channel msg)
-          true)
-
-        true
-        (warn "Ignored message while importing: " msg)))))
+;; {:id "15890",
+;;  :name "Type",
+;;  :code "type",
+;;  :kind "select_one",
+;;  :config {:options [{:id 1, :code "hospital", :label "Hospital"}
+;;                     {:id 2, :code "health center", :label "Health Center"}
+;;                     {:id 3, :code "dispensary", :label "Dispensary"}],
+;;           :next_id 4}}
 
 (defn import-types
+  "Import the facility types from a Resourcemap 'select-one' field definition."
   [facilities type-field]
   (info "Importing facility types from Resourcemap field" (:id type-field))
+  (facilities/destroy-facilities! facilities)
   (facilities/destroy-types! facilities)
   (let [options (get-in type-field [:config :options])
         types (map (fn [{label :label}] {:name label}) options)
@@ -48,10 +40,15 @@
     {:code (:code type-field)
      :options new-options}))
 
-(defn sites-with-location [sites]
+(defn sites-with-location
+  "Filter Resourcemap sites which have a valid location"
+  [sites]
   (filter #(and (:lat %) (:long %)) sites))
 
-(defn facility-type-ctor [type-field]
+(defn facility-type-ctor
+  "Returns a function which applied to a Resourcemap site returns the facility
+  type according to the given type field (as returned from import-types)."
+  [type-field]
   (let [field-name (:code type-field)
         options (:options type-field)
         type-path [:properties (keyword field-name)]]
@@ -59,141 +56,164 @@
       (let [f_type (get-in site type-path)]
         (get options f_type)))))
 
-(defn site->facility-ctor [type-field]
+(defn site->facility-ctor
+  "Returns a function to transform a Resourcemap site into a valid Facility
+  using the facility type information given."
+  [type-field]
   (let [facility-type (facility-type-ctor type-field)]
     (fn [site]
       (-> site
           (select-keys [:id :name :lat :long])
           (rename-keys {:long :lon})
-          (assoc :type_id (facility-type site))))))
+          (assoc :type-id (facility-type site))))))
 
-(defn sites->facilities [sites type-field]
+(defn sites->facilities
+  "Filters and transforms a list of Resourcemap sites into a list of facilities
+  using the given facility type field definition."
+  [sites type-field]
   (->> sites
        (sites-with-location)
        (map (site->facility-ctor type-field))))
 
-(defn do-import-sites
-  [{:keys [resmap facilities] :as service} user coll-id type-field]
-  (loop [page 1
-         ids []]
-    (when (import-cancelled? service)
-      (throw (RuntimeException. "Import cancelled while importing sites")))
-    (let [data (resmap/get-collection-sites resmap user coll-id {:page page})
-          sites (:sites data)]
-      (if (seq sites)
-        (do (info "Processing page" page "of collection" coll-id)
-            (let [new-facilities (sites->facilities sites type-field)]
-              (info "Inserting" (count new-facilities) "facilities")
-              (facilities/insert-facilities! facilities new-facilities)
-              (recur (inc page) (into ids (map :id new-facilities)))))
-        ids))))
+(defn import-collection-page
+  "Request a single page of sites from a Resourcemap collection and import the
+  sites as facilities. Returns nil when Resourcemap returns no sites, or
+  [:continue ids] where ids are from the inserted facilities."
+  [{:keys [resmap facilities]} user coll-id type-field page]
+  (info (str "Requesting page " page " of collection " coll-id " from Resourcemap"))
+  (let [data (resmap/get-collection-sites resmap user coll-id {:page page})
+        sites (:sites data)]
+    (when (seq sites)
+      (info "Processing page" page "of collection" coll-id)
+      (let [new-facilities (sites->facilities sites type-field)]
+        (info "Inserting" (count new-facilities) "facilities")
+        (facilities/insert-facilities! facilities new-facilities)
+        [:continue (map :id new-facilities)]))))
 
-(defn preprocess-isochrones
-  [{:keys [facilities status] :as service} ids]
-  (let [total-facilities (count ids)]
-    (info "Preprocessing isochrones for" total-facilities "facilities")
-    (doseq [[idx facility-id] (map-indexed vector ids)]
-      (when (import-cancelled? service)
-        (throw (RuntimeException. "Import cancelled while processing isochrones")))
-      (let [progress (str (inc idx) "/" total-facilities)]
-        (info "Preprocessing facility" facility-id progress)
-        (swap! status (constantly [:importing :processing progress])))
-      (facilities/preprocess-isochrones facilities facility-id))))
+(defn process-facilities
+  [facilities facility-ids]
+  (doseq [id facility-ids]
+    (facilities/preprocess-isochrones facilities id)))
 
 (defn update-projects
-  [{:keys [projects status] :as service}]
-  (info "Updating projects stats")
-  (swap! status (constantly [:importing :updating]))
+  [projects]
   (let [list (projects/list-projects projects)]
     (doseq [project list]
       (projects/update-project-stats projects project))))
 
-(defn do-import-collection
-  [{:keys [resmap facilities] :as service} user coll-id type-field]
-  (info "Destroying existing facilities")
-  (facilities/destroy-facilities! facilities)
-  (try
-    (let [type-field (import-types facilities type-field)
-          ids (do-import-sites service user coll-id type-field)]
-      (preprocess-isochrones service ids)
-      (info "Done importing facilities from collection" coll-id))
 
-    (finally
-      (update-projects service))))
+;; ----------------------------------------------------------------------------
+;; Job control
 
-(defn service-loop
-  [service]
-  (info "Starting importer service")
-  (let [c (:control-channel service)
-        status (:status service)]
-    (go-loop []
-      (let [msg (<! c)]
-        (info "Received message" msg)
-        (if-not (= (first msg) :quit)
-          (do
-            (cond
-              (= (first msg) :set-status)
-              (swap! status (constantly (second msg)))
+(defn try-accept-job
+  [old-job new-job]
+  (if (import-job/job-finished? old-job)
+    new-job
+    old-job))
 
-              (= (first msg) :import!)
-              (let [params (second msg)
-                    ident (:user params)
-                    coll-id (:coll-id params)
-                    type-field (:type-field params)]
-                (swap! status (constantly [:importing "Importing collection"]))
-                (try
-                  (do-import-collection service ident coll-id type-field)
-                  (swap! status (constantly [:ready :success]))
-                  (catch Exception e
-                    (error e "Error running import job")
-                    (swap! status (constantly [:ready :failed])))))
+(defn build-task-fn
+  [{:keys [facilities projects resmap]} job task]
+  (case (import-job/task-type task)
+    :import-types
+    (let [type-field (import-job/job-type-field job)]
+      (partial import-types facilities type-field))
 
-              true
-              (warn "Unknown message received" msg))
-            (recur))
-          (info "Finishing importer service")))))
-  service)
+    :import-sites
+    (let [services {:resmap resmap
+                    :facilities facilities}
+          user-ident (import-job/job-user-ident job)
+          coll-id (import-job/job-collection-id job)
+          type-field (import-job/job-type-field job)
+          page (second task)]
+      (partial import-collection-page services user-ident coll-id type-field page))
 
-(defrecord Importer [status control-channel resmap facilities projects]
+    :process-facilities
+    (let [facility-ids (second task)]
+      (partial process-facilities facilities facility-ids))
+
+    :update-projects
+    (partial update-projects projects)))
+
+(defn log-job-status
+  [job]
+  (when (import-job/job-finished? job)
+    (let [result (import-job/job-result job)]
+      (info "Import job finished with result:" result))))
+
+
+;; ----------------------------------------------------------------------------
+;; Service definition
+
+(defrecord Importer [job taskmaster resmap facilities projects]
   component/Lifecycle
   (start [component]
     (info "Starting Importer component")
-    (if-not (:status component)
-      (let [c (chan)]
-        (-> component
-            (assoc :status (atom :ready)
-                   :control-channel c)
-            (service-loop)))
+    (if-not (:taskmaster component)
+      (let [job (atom nil)
+            component (assoc component :job job)
+            taskmaster (taskmaster/run-taskmaster component)]
+        (assoc component :taskmaster taskmaster))
       component))
   (stop [component]
     (info "Stopping Importer component")
-    (when-let [c (:control-channel component)]
-      (put! c [:quit]))
-    (dissoc component :status :control-channel)))
+    (when-let [taskmaster (:taskmaster component)]
+      (taskmaster/quit taskmaster))
+    (dissoc component :job :taskmaster))
+
+  taskmaster/TaskDispatcher
+  (next-task [component]
+    (if-not (import-job/job-finished? @(:job component))
+      (let [job (swap! (:job component) import-job/next-task)
+            task (import-job/job-peek-next-task job)]
+        (log-job-status job)
+        (if (and (not (import-job/job-finished? job)) task)
+          (do
+            (info "Importer/next-task:" task)
+            {:task-id task
+             :task-fn (build-task-fn component job task)})
+          (do
+            (info "No more tasks to execute")
+            nil)))
+      (info "Nothing to do")))
+
+  (task-completed [component task-id result]
+    (info "Importer/task-completed" task-id result)
+    (let [job (swap! (:job component) import-job/report-task-success task-id result)]
+      (log-job-status job)))
+
+  (task-failed [component task-id error-info]
+    (info "Importer/task-failed" task-id error-info)
+    (let [job (swap! (:job component) import-job/report-task-failure task-id error-info)]
+      (log-job-status job))))
 
 (defn importer
+  "Constructs an Importer service"
   ([]
    (importer {}))
   ([config]
    (map->Importer config)))
 
-(defn status
-  [service]
-  @(:status service))
 
-(defn send-msg
-  [service msg]
-  (put! (:control-channel service) msg))
+;; Importer public API
+
+(defn status
+  "Retrieve the importer's current status"
+  [service]
+  (import-job/job-status @(:job service)))
 
 (defn import-collection
-  [service user coll-id type-field]
-  ;; TODO: this shouldn't be here, but otherwise this function returns before
-  ;; the job is processed and the status is still :ready
-  (swap! (:status service) (constantly [:importing "Starting..."]))
-  (send-msg service [:import! {:user user
-                               :coll-id coll-id
-                               :type-field type-field}]))
+  [service user-ident coll-id type-field]
+  (let [new-job (import-job/create-job user-ident coll-id type-field)
+        accepted-job (swap! (:job service) #(try-accept-job % new-job))]
+    (if (= new-job accepted-job)
+      (do
+        (let [result (taskmaster/poll-dispatcher (:taskmaster service))]
+          (when (= :error (first result))
+            (throw (ex-info "Failure starting the import job" {:result result}))))
+        (status service))
+      [:error :busy])))
 
 (defn cancel-import!
   [service]
-  (send-msg service [:cancel]))
+  (swap! (:job service) import-job/cancel-job)
+  (status service))

--- a/src/planwise/component/importer.clj
+++ b/src/planwise/component/importer.clj
@@ -146,14 +146,15 @@
 ;; ----------------------------------------------------------------------------
 ;; Service definition
 
-(defrecord Importer [job taskmaster resmap facilities projects]
+(defrecord Importer [job taskmaster concurrent-workers resmap facilities projects]
   component/Lifecycle
   (start [component]
     (info "Starting Importer component")
     (if-not (:taskmaster component)
       (let [job (atom nil)
+            concurrent-workers (or (:concurrent-workers component) 1)
             component (assoc component :job job)
-            taskmaster (taskmaster/run-taskmaster component)]
+            taskmaster (taskmaster/run-taskmaster component concurrent-workers)]
         (assoc component :taskmaster taskmaster))
       component))
   (stop [component]

--- a/src/planwise/component/taskmaster.clj
+++ b/src/planwise/component/taskmaster.clj
@@ -8,9 +8,8 @@
 (timbre/refer-timbre)
 
 (def Task
-  {:task-id s/Int
-   :work-fn (s/pred fn?)
-   :work-data s/Any})
+  {:task-id s/Any
+   :task-fn (s/pred fn?)})
 
 (defprotocol TaskDispatcher
   (next-task [this]
@@ -43,10 +42,10 @@
   nil)
 
 (defn dispatch-task
-  [{:keys [task-id work-fn work-data]}]
+  [{:keys [task-id task-fn]}]
   (go
     (try
-      (let [result (work-fn work-data)]
+      (let [result (task-fn)]
         {:task-id task-id
          :status :ok
          :data result})
@@ -147,6 +146,9 @@
                (let [new-state (process-worker-msg state channel-msg msg)]
                  (when (some? new-state)
                    (recur new-state))))))
+
+         (catch Exception e
+           (warn "Exception in Taskmaster" e))
 
          (finally
            (close! control-channel))))

--- a/src/planwise/component/taskmaster.clj
+++ b/src/planwise/component/taskmaster.clj
@@ -50,6 +50,7 @@
          :status :ok
          :data result})
       (catch Exception e
+        (warn e "Error executing task")
         {:task-id task-id
          :status :error
          :error e}))))
@@ -148,7 +149,7 @@
                    (recur new-state))))))
 
          (catch Exception e
-           (warn "Exception in Taskmaster" e))
+           (fatal e "Exception in Taskmaster"))
 
          (finally
            (close! control-channel))))

--- a/src/planwise/component/taskmaster.clj
+++ b/src/planwise/component/taskmaster.clj
@@ -1,0 +1,181 @@
+(ns planwise.component.taskmaster
+  (:require [com.stuartsierra.component :as component]
+            [taoensso.timbre :as timbre]
+            [schema.core :as s]
+            [clojure.core.async :refer [chan close! put! <! >! go
+                                        alt!! alts! alts!! timeout]]))
+
+(timbre/refer-timbre)
+
+(def Task
+  {:task-id s/Int
+   :work-fn (s/pred fn?)
+   :work-data s/Any})
+
+(defprotocol TaskDispatcher
+  (next-task [this]
+    "Retrieve the next available task, or nil if there is none.")
+  (task-completed [this task-id result]
+    "Report back the successful execution of the task identified by task-id.
+    result is the task value.")
+  (task-failed [this task-id error-info]
+    "Report back the failed execution of the task identified by task-id.
+    error-info contains the task exception information."))
+
+(declare process-worker-msg)
+
+(defn wait-workers
+  [{:keys [workers] :as state}]
+  (when (pos? (count workers))
+    (info (str "Waiting 10s for " (count workers) " workers"))
+    (let [wait-timeout (timeout 10000)]
+      (loop [state state]
+        (let [workers (:workers state)
+              channels (conj workers wait-timeout)
+              [msg channel-msg] (alts!! channels)]
+          (if (= wait-timeout channel-msg)
+            (do
+              (warn (str "Timeout waiting for workers to finish. "
+                         (count workers) " didn't finish")))
+            (let [new-state (process-worker-msg state channel-msg msg)]
+              (when (seq (:workers new-state))
+                (recur new-state))))))))
+  nil)
+
+(defn dispatch-task
+  [{:keys [task-id work-fn work-data]}]
+  (go
+    (try
+      (let [result (work-fn work-data)]
+        {:task-id task-id
+         :status :ok
+         :data result})
+      (catch Exception e
+        {:task-id task-id
+         :status :error
+         :error e}))))
+
+(defn try-spawn-worker
+  [dispatcher]
+  (debug "Polling task dispatcher...")
+  (when-let [task (and dispatcher (next-task dispatcher))]
+    (dispatch-task task)))
+
+(defn can-spawn-worker?
+  [{:keys [workers scale]}]
+  (> scale (count workers)))
+
+(defn execute-control-msg
+  [state {:keys [command] :as msg}]
+  (if (nil? msg)
+    (do
+      (warn "Control channel closed! Aborting Taskmaster...")
+      (wait-workers state))
+
+    (case command
+      :quit
+      (let [new-state (wait-workers state)]
+        (info "Taskmaster finished")
+        [new-state :finished])
+
+      :ping
+      [state :pong]
+
+      :poll-dispatcher
+      ;; dispatcher will be polled on the next event loop iteration
+      [state :ok]
+
+      ;; else
+      (do
+        (warn (str "Got unknown command " (dissoc msg :channel)))
+        [state :unknown-command]))))
+
+(defn process-control-msg
+  [state msg]
+  (debug "Got control message:" msg)
+  (let [channel (:channel msg)
+        [new-state reply] (execute-control-msg state msg)]
+    (when (and channel (some? reply))
+      (put! channel reply))
+    new-state))
+
+(defn process-worker-msg
+  [state worker-channel msg]
+  (debug "Got worker message:" msg)
+  (let [dispatcher (:dispatcher state)
+        task-id (:task-id msg)
+        task-status (:status msg)]
+    (case task-status
+      :ok
+      (task-completed dispatcher task-id (:data msg))
+      :error
+      (task-failed dispatcher task-id (:error msg))))
+  (update-in state [:workers] #(filterv (partial not= worker-channel) %)))
+
+(defn spawn-workers
+  [state]
+  (if-let [new-worker (and (can-spawn-worker? state)
+                           (try-spawn-worker (:dispatcher state)))]
+    (recur (update-in state [:workers] #(conj % new-worker)))
+    state))
+
+(defn run-taskmaster
+  ([dispatcher]
+   (run-taskmaster dispatcher 1))
+  ([dispatcher scale]
+   (let [control-channel (chan)]
+     (go
+       (info "Taskmaster started")
+       (try
+         (loop [state {:dispatcher dispatcher
+                       :scale scale
+                       :workers []}]
+           (let [state (spawn-workers state)
+                 worker-channels (vec (:workers state))
+                 channels (conj worker-channels control-channel)
+                 [msg channel-msg] (alts! channels)
+                 source (if (= control-channel channel-msg)
+                          :control
+                          :worker)]
+             (case source
+               :control
+               (let [new-state (process-control-msg state msg)]
+                 (when (some? new-state)
+                   (recur new-state)))
+
+               :worker
+               (let [new-state (process-worker-msg state channel-msg msg)]
+                 (when (some? new-state)
+                   (recur new-state))))))
+
+         (finally
+           (close! control-channel))))
+
+     control-channel)))
+
+
+(defn send-command
+  ([control-channel command]
+   (send-command control-channel command 5000))
+  ([control-channel command wait]
+   (let [command (if (map? command) command {:command command})
+         response-channel (chan)]
+     (if (put! control-channel (assoc command :channel response-channel))
+       (alt!!
+         response-channel ([val _ch] [:ok val])
+         (timeout wait) [:error :timeout])
+       [:error :closed]))))
+
+
+(defn ping
+  [control-channel]
+  (send-command control-channel :ping))
+
+(defn quit
+  [control-channel]
+  ;; Wait 1s more than the wait timeout
+  (send-command control-channel :quit 11000))
+
+(defn poll-dispatcher
+  [control-channel]
+  (send-command control-channel :poll-dispatcher))

--- a/src/planwise/component/taskmaster.clj
+++ b/src/planwise/component/taskmaster.clj
@@ -125,7 +125,7 @@
   ([dispatcher scale]
    (let [control-channel (chan)]
      (go
-       (info "Taskmaster started")
+       (info (str "Taskmaster started (concurrency " scale ")"))
        (try
          (loop [state {:dispatcher dispatcher
                        :scale scale

--- a/src/planwise/config.clj
+++ b/src/planwise/config.clj
@@ -9,7 +9,7 @@
    :paths      {:bin                 "bin/"
                 :scripts             "scripts/"
                 :data                "data/"}
-   :maps       {:mapserver-url       "http://planwise-maps-stg.instedd.org/mapcache?"
+   :maps       {:mapserver-url       "http://localhost:5002/mapcache?"
                 :facilities-capacity 100000
                 :calculate-demand    true}
    :facilities {:raster-isochrones true}})

--- a/src/planwise/config.clj
+++ b/src/planwise/config.clj
@@ -12,7 +12,8 @@
    :maps       {:mapserver-url       "http://localhost:5002/mapcache?"
                 :facilities-capacity 100000
                 :calculate-demand    true}
-   :facilities {:raster-isochrones true}})
+   :facilities {:raster-isochrones   true}
+   :importer   {:concurrent-workers  2}})
 
 (def environ
   {:http       {:port                 (some-> env :port Integer.)}
@@ -29,4 +30,5 @@
    :maps       {:mapserver-url        (env :mapserver-url)
                 :facilities-capacity  (some-> env :maps-facilities-capacity Integer.)
                 :calculate-demand     (some-> env :calculate-demand (Boolean/valueOf))}
-   :facilities {:raster-isochrones    (some-> env :raster-isochrones (Boolean/valueOf))}})
+   :facilities {:raster-isochrones    (some-> env :raster-isochrones (Boolean/valueOf))}
+   :importer   {:concurrent-workers   (some-> env :concurrent-workers Integer.)}})

--- a/src/planwise/model/facilities.clj
+++ b/src/planwise/model/facilities.clj
@@ -13,6 +13,7 @@
   {:id                         s/Int
    :name                       s/Str
    (s/optional-key :type)      s/Str
+   (s/optional-key :type-id)   s/Int
    :lat                        s/Num
    :lon                        s/Num
    (s/optional-key :isochrone) GeoJSON})

--- a/src/planwise/model/import_job.clj
+++ b/src/planwise/model/import_job.clj
@@ -1,0 +1,331 @@
+(ns planwise.model.import-job
+  (:require [reduce-fsm :as fsm]
+            [schema.core :as s]
+            [clojure.core.match :refer [match]]))
+
+
+;; Import job tasks
+
+(s/defschema ImportTask
+  "Task identification values"
+  (s/conditional
+   #(= % :import-types)
+   (s/eq :import-types)
+
+   #(and (coll? %) (= (first %) :import-sites))
+   (s/pair (s/eq :import-sites) "type" s/Int "page")
+
+   #(and (coll? %) (= (first %) :process-facilities))
+   (s/pair (s/eq :process-facilities) "type" [s/Int] "ids")
+
+   #(= % :update-projects)
+   (s/eq :update-projects)))
+
+(defn task-type
+  [task-id]
+  (cond
+    (keyword? task-id) task-id
+    (coll? task-id) (first task-id)
+    true nil))
+
+
+;; Task queue functions
+
+(defn push-task
+  [tasks task]
+  (if-not (= task (peek tasks))
+    (conj tasks task)
+    tasks))
+
+(defn peek-task
+  [tasks]
+  (peek tasks))
+
+(defn remove-task
+  [tasks task]
+  (->> tasks
+       (remove #(= task %))
+       vec))
+
+
+;; FSM value update functions
+
+(defn cancel-import
+  [job & _]
+  (assoc job :result :cancelled))
+
+(defn unexpected-event
+  [job evt state & _]
+  (assoc job
+         :result :unexpected-event
+         :event evt
+         :last-state state))
+
+(defn clear-dispatch
+  [job & _]
+  (update job :tasks push-task nil))
+
+(defn complete-task
+  [job [_ task _] & _]
+  (update job :tasks remove-task task))
+
+(defn dispatch-import-types
+  [job & _]
+  (update job :tasks push-task :import-types))
+
+(defn import-types-succeeded
+  [job event & _]
+  (let [[_ _ data] event]
+    (-> (complete-task job event)
+        (assoc :type-field data))))
+
+(defn import-types-failed
+  [job event & _]
+  (let [[_ _ error] event]
+    (-> (complete-task job event)
+        (assoc :result :import-types-failed
+               :error-info error))))
+
+(defn dispatch-import-sites
+  [job & _]
+  (let [page (:page job)]
+    (update job :tasks push-task [:import-sites page])))
+
+(defn import-sites-succeeded
+  [job event & _]
+  (let [page (:page job)
+        facility-ids (:facility-ids job)
+        [_ _ [_ page-ids]] event]
+    (-> (complete-task job event)
+        (assoc :page (inc page)
+               :facility-ids (into facility-ids page-ids)))))
+
+(defn import-sites-failed
+  [job event & _]
+  (let [[_ _ error] event]
+    (-> (complete-task job event)
+        (assoc :result :import-sites-failed
+               :error-info error))))
+
+(defn dispatch-process-facilities
+  [job & _]
+  (let [facility-ids (:facility-ids job)
+        next-facility (first facility-ids)]
+    (if (nil? next-facility)
+      (clear-dispatch job)
+      (-> job
+          (update :tasks push-task [:process-facilities [next-facility]])
+          (update :facility-ids rest)))))
+
+(defn complete-processing
+  [job event & _]
+  ;; TODO: save the processing result in the job
+  (complete-task job event))
+
+(defn dispatch-update-projects
+  [job & _]
+  (update job :tasks push-task :update-projects))
+
+(defn update-projects-succeeded
+  [job event & _]
+  (-> (complete-task job event)
+      (assoc :result :success)))
+
+(defn update-projects-failed
+  [job event & _]
+  (let [[_ _ error] event]
+    (-> (complete-task job event)
+        (assoc :result :update-projects-failed
+               :error-info error))))
+
+
+;; FSM guards
+
+(defn task-report?
+  [event]
+  (and (coll? event) (case (first event) (:success :failure) true false)))
+
+(defn event-task-report?
+  [[_ event]]
+  (task-report? event))
+
+(defn last-task-report?
+  [[{tasks :tasks} event]]
+  (and (task-report? event)
+       (or (empty? tasks)
+           (and (= 1 (count tasks))
+                (= (first tasks) (second event))))))
+
+(defn page-number-mismatch?
+  [[{page :page} event]]
+  (when (task-report? event)
+    (let [[_ task _] event
+          event-page (match task [:import-sites p] p :else :no-match)]
+      (and (number? event-page)
+           (not= page event-page)))))
+
+(defn no-pending-tasks?
+  [{tasks :tasks}]
+  (empty? tasks))
+
+(defn process-report?
+  [event]
+  (and (task-report? event)
+       (= :process-facilities (first (second event)))))
+
+(defn done-processing?
+  [[job event]]
+  (and (empty? (:facility-ids job))
+       (process-report? event)
+       (last-task-report? [job event])))
+
+
+;; FSM definition
+
+(def default-job-value
+  {:user-ident    nil
+   :collection-id nil
+   :type-field    nil
+   :page          1
+   :facility-ids  []
+   :tasks         []
+   :result        nil
+   :last-event    nil})
+
+(fsm/defsm-inc import-job
+  [[:start
+    [[_ :next]]                      -> {:action dispatch-import-types} :importing-types
+    [[_ :cancel]]                    -> {:action cancel-import} :error
+    [[_ _]]                          -> {:action unexpected-event} :error]
+
+   [:importing-types
+    [[_ [:success :import-types _]]] -> {:action import-types-succeeded} :request-sites
+    [[_ [:failure :import-types _]]] -> {:action import-types-failed} :error
+    [[_ :next]]                      -> {:action clear-dispatch} :importing-types
+    [[_ :cancel]]                    -> {:action cancel-import} :cancelling
+    [[_ _]]                          -> {:action unexpected-event} :error]
+
+   [:request-sites
+    [[_ :next]]                      -> {:action dispatch-import-sites} :importing-sites
+    [[_ :cancel]]                    -> {:action cancel-import} :clean-up
+    [[_ _]]                          -> {:action unexpected-event} :error]
+
+   [:importing-sites
+    [_ :guard page-number-mismatch?] -> {:action unexpected-event} :error
+    [[_ [:success [:import-sites _] [:continue _]]]]
+                                     -> {:action import-sites-succeeded} :request-sites
+    [[_ [:success [:import-sites _] _]]]
+                                     -> {:action import-sites-succeeded} :processing-facilities
+    [[_ [:failure [:import-sites _] _]]]
+                                     -> {:action import-sites-failed} :clean-up
+    [[_ :next]]                      -> {:action clear-dispatch} :importing-sites
+    [[_ :cancel]]                    -> {:action cancel-import} :cancelling
+    [[_ _]]                          -> {:action unexpected-event} :error]
+
+   [:processing-facilities
+    [[_ :next]]                      -> {:action dispatch-process-facilities} :processing-facilities
+    [[(_ :guard no-pending-tasks?) :cancel]]
+                                     -> {:action cancel-import} :clean-up
+    [[_ :cancel]]                    -> {:action cancel-import} :cancelling
+    [_ :guard done-processing?]      -> {:action complete-processing} :update-projects
+    [[_ (_ :guard process-report?)]]       -> {:action complete-processing} :processing-facilities
+    [[_ _]]                          -> {:action unexpected-event} :error]
+
+   [:update-projects
+    [[_ :next]]                      -> {:action dispatch-update-projects} :updating-projects
+    [[_ :cancel]]                    -> {:action cancel-import} :clean-up
+    [[_ _]]                          -> {:action unexpected-event} :error]
+
+   [:updating-projects
+    [[_ :next]]                      -> {:action clear-dispatch} :updating-projects
+    [[_ :cancel]]                    -> {:action cancel-import} :clean-up-wait
+    [[_ [:success :update-projects _]]]
+                                     -> {:action update-projects-succeeded} :done
+    [[_ [:failure :update-projects _]]]
+                                     -> {:action update-projects-failed} :error
+    [[_ _]]                          -> {:action unexpected-event} :error]
+
+   [:cancelling
+    [_ :guard last-task-report?]     -> {:action complete-task} :clean-up
+    [_ :guard event-task-report?]    -> {:action complete-task} :cancelling
+    [[_ :cancel]]                    -> :cancelling
+    [[_ :next]]                      -> {:action clear-dispatch} :cancelling]
+
+   [:clean-up
+    [[_ :next]]                      -> {:action dispatch-update-projects} :clean-up-wait
+    [[_ :cancel]]                    -> :clean-up
+    [[_ _]]                          -> {:action unexpected-event} :error]
+
+   [:clean-up-wait
+    [_ :guard last-task-report?]     -> {:action complete-task} :error
+    [_ :guard event-task-report?]    -> {:action complete-task} :clean-up-wait
+    [[_ :cancel]]                    -> :clean-up-wait
+    [[_ :next]]                      -> {:action clear-dispatch} :clean-up-wait]
+
+   [:error   {:is-terminal true}]
+   [:done    {:is-terminal true}]]
+
+  :default-acc default-job-value
+
+  :dispatch :event-acc-vec)
+
+(defn job-peek-next-task
+  [job]
+  (peek-task (get-in job [:value :tasks])))
+
+(defn job-result
+  [job]
+  (get-in job [:value :result]))
+
+(defn job-user-ident
+  [job]
+  (get-in job [:value :user-ident]))
+
+(defn job-collection-id
+  [job]
+  (get-in job [:value :collection-id]))
+
+(defn job-type-field
+  [job]
+  (get-in job [:value :type-field]))
+
+(defn job-status
+  [job]
+  (let [state (:state job)]
+    (cond
+      (nil? state) :ready
+      (keyword? state) state
+      true :unknown)))
+
+(defn create-job
+  [user-ident coll-id type-field]
+  (let [job-value (assoc default-job-value
+                         :user-ident user-ident
+                         :collection-id coll-id
+                         :type-field type-field)]
+    (import-job job-value)))
+
+(defn job-finished?
+  [job]
+  (or (nil? job)
+      (:is-terminated? job)))
+
+(defn cancel-job
+  [job]
+  (when job
+    (fsm/fsm-event job :cancel)))
+
+(defn next-task
+  [job]
+  (when job
+    (fsm/fsm-event job :next)))
+
+(defn report-task-success
+  [job task-id data]
+  (when job
+    (fsm/fsm-event job [:success task-id data])))
+
+(defn report-task-failure
+  [job task-id error-info]
+  (when job
+    (fsm/fsm-event job [:failure task-id error-info])))

--- a/src/planwise/system.clj
+++ b/src/planwise/system.clj
@@ -80,15 +80,14 @@
 
 (def session-config
   {:cookies true
-   :session {:flash true
-             :store (cookie-store)
+   :session {:store (cookie-store)
              :cookie-attrs {:max-age (* 24 3600)}
              :cookie-name "planwise-session"}})
 
 (def base-config
   {:auth {:jwe-secret  jwe-secret
           :jwe-options jwe-options}
-   :api {:middleware   [[wrap-authorization :auth-backend]
+   :api {:middleware   [[wrap-authorization :jwe-auth-backend]
                         [wrap-authentication :session-auth-backend :jwe-auth-backend]
                         [wrap-json-params]
                         [wrap-json-response]
@@ -107,7 +106,8 @@
          :jar-resources "public/assets"
          :app-defaults (meta-merge site-defaults
                                    session-config
-                                   {:static {:resources "planwise/public"}})}
+                                   {:session {:flash true}
+                                    :static {:resources "planwise/public"}})}
    :app-auth-backend {:unauthorized-handler app-unauthorized-handler}
 
    :webapp {:middleware [[wrap-gzip]

--- a/src/planwise/system.clj
+++ b/src/planwise/system.clj
@@ -166,7 +166,7 @@
          :routing             (routing-service)
          :users-store         (users-store)
          :resmap              (resmap-client (:resmap config))
-         :importer            (importer)
+         :importer            (importer (:importer config))
          :runner              (runner-service (:paths config))
          :maps                (maps-service (meta-merge (:maps config)
                                                         (:paths config)))

--- a/src/planwise/util/ring.clj
+++ b/src/planwise/util/ring.clj
@@ -26,3 +26,11 @@
   [request]
   (-> (request-ident request)
       ident/user-email))
+
+(defn wrap-debug-request
+  "Middleware to print each request to the console"
+  [handler]
+  (fn [request]
+    (println (str "\n\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="))
+    (clojure.pprint/pprint request)
+    (handler request)))

--- a/test/planwise/component/facilities_test.clj
+++ b/test/planwise/component/facilities_test.clj
@@ -18,7 +18,7 @@
     [{:facility_id 1 :threshold 900 :method "alpha-shape" :the_geom (sample-polygon)}]]])
 
 (def new-facilities
-  [{:id 3 :name "New facility" :type_id 1 :lat 4 :lon 10 :type "hospital"}])
+  [{:id 3 :name "New facility" :type-id 1 :lat 4 :lon 10 :type "hospital"}])
 
 (defn system []
   (into

--- a/test/planwise/component/taskmaster_test.clj
+++ b/test/planwise/component/taskmaster_test.clj
@@ -1,0 +1,39 @@
+(ns planwise.component.taskmaster-test
+  (:require [planwise.component.taskmaster :as sut]
+            [clojure.test :as t]))
+
+;; Dummy test implementation of TaskDispatcher
+
+(def next-task-id (atom 0))
+(def tasks (atom []))
+
+(defn pop-task
+  []
+  (let [current-tasks @tasks
+        task (peek current-tasks)
+        updated-tasks (if (empty? current-tasks)
+                        current-tasks
+                        (pop current-tasks))]
+    (if (compare-and-set! tasks current-tasks updated-tasks)
+      task
+      (recur))))
+
+(defn queue-task
+  ([task-fn]
+   (queue-task (fn [_] (task-fn)) nil))
+  ([task-fn task-data]
+   (let [task-id (swap! next-task-id inc)
+         task {:task-id task-id
+               :work-fn task-fn
+               :work-data task-data}]
+     (swap! tasks #(vec (cons task %)))
+     task-id)))
+
+(def dummy-task-dispatcher
+  (reify sut/TaskDispatcher
+    (next-task [this]
+      (pop-task))
+    (task-completed [this task-id result]
+      (println (str "Task #" task-id " completed successfully with result " result)))
+    (task-failed [this task-id error-info]
+      (println (str "Task #" task-id " failed with " error-info)))))

--- a/test/planwise/component/taskmaster_test.clj
+++ b/test/planwise/component/taskmaster_test.clj
@@ -20,12 +20,9 @@
 
 (defn queue-task
   ([task-fn]
-   (queue-task (fn [_] (task-fn)) nil))
-  ([task-fn task-data]
    (let [task-id (swap! next-task-id inc)
          task {:task-id task-id
-               :work-fn task-fn
-               :work-data task-data}]
+               :task-fn task-fn}]
      (swap! tasks #(vec (cons task %)))
      task-id)))
 

--- a/test/planwise/model/import_job_test.clj
+++ b/test/planwise/model/import_job_test.clj
@@ -58,7 +58,7 @@
       ;; unexpected/invalid event
       (is (= (reduce-job initial [:foo])          [:error nil :unexpected-event]))
       ;; user cancels after the import types task was dispatched
-      (is (= (reduce-job initial [:next :cancel]) [:cancelling :import-types :cancelled]))
+      (is (= (reduce-job initial [:next :cancel]) [:cancelling nil :cancelled]))
 
       ;; user cancels while importing facility types
       (is (= (reduce-job initial [:next
@@ -136,7 +136,15 @@
             (is (= (reduce-job job [:next :next
                                     [:success [:process-facilities [1]] nil]
                                     [:success [:process-facilities [2]] nil]])
-                   [:done nil :success]))))))
+                   [:done nil :success]))
+
+            ;; cancellations during this stage
+            (is (= (reduce-job job [:cancel])
+                   [:error nil :cancelled]))
+            (is (= (reduce-job job [:next :cancel])
+                   [:clean-up-wait nil :cancelled]))
+            (is (= (reduce-job job [:next :cancel [:success [:process-facilities [1]] nil]])
+                   [:error nil :cancelled]))))))
 
     ;; TODO: test error conditions in all stages
     ;; TODO: test cancellation in all stages

--- a/test/planwise/model/import_job_test.clj
+++ b/test/planwise/model/import_job_test.clj
@@ -8,15 +8,9 @@
   (is (= [] (sut/push-task [] nil)))
   (is (= [:foo] (sut/push-task [] :foo)))
   (is (= [:foo] (sut/push-task [:foo] :foo)))
-  (is (= [:foo nil] (sut/push-task [:foo] nil)))
+  (is (= [:foo] (sut/push-task [:foo] nil)))
   (is (= [:foo :bar] (sut/push-task [:foo] :bar)))
   (is (= [:foo :bar :foo] (sut/push-task [:foo :bar] :foo))))
-
-(deftest peek-task-test
-  (is (nil? (sut/peek-task nil)))
-  (is (nil? (sut/peek-task [])))
-  (is (nil? (sut/peek-task [nil])))
-  (is (= :foo (sut/peek-task [:foo]))))
 
 (deftest remove-task-test
   (is (= [] (sut/remove-task [] nil)))
@@ -138,7 +132,7 @@
             (is (= (reduce-job job [:next [:success [:process-facilities [1]] nil] :next])
                    [:processing-facilities [:process-facilities [2]] nil]))
             (is (= (reduce-job job [:next :next [:success [:process-facilities [1]] nil]])
-                   [:processing-facilities [:process-facilities [2]] nil]))
+                   [:processing-facilities nil nil]))
             (is (= (reduce-job job [:next :next
                                     [:success [:process-facilities [1]] nil]
                                     [:success [:process-facilities [2]] nil]])

--- a/test/planwise/model/import_job_test.clj
+++ b/test/planwise/model/import_job_test.clj
@@ -89,19 +89,19 @@
       (is (= (reduce-job initial [:next])
              [:importing-sites [:import-sites 1] nil]))
       ;; single page of sites successfully imported
-      (is (= (reduce-job initial [:next [:success [:import-sites 1] [nil [1 2 3]]]])
+      (is (= (reduce-job initial [:next [:success [:import-sites 1] [nil [1 2 3] 1]]])
              [:processing-facilities nil nil]))
       ;; page of sites successfully imported (continue)
-      (is (= (reduce-job initial [:next [:success [:import-sites 1] [:continue [1 2 3]]]])
+      (is (= (reduce-job initial [:next [:success [:import-sites 1] [:continue [1 2 3] 5]]])
              [:request-sites nil nil]))
       ;; page report mismatch
-      (is (= (reduce-job initial [:next [:success [:import-sites 2] [nil [1 2 3]]]])
+      (is (= (reduce-job initial [:next [:success [:import-sites 2] [nil [1 2 3] 4]]])
              [:error [:import-sites 1] :unexpected-event]))
       ;; sites page is incremented
-      (is (= (reduce-job initial [:next [:success [:import-sites 1] [:continue [1 2 3]]] :next])
+      (is (= (reduce-job initial [:next [:success [:import-sites 1] [:continue [1 2 3] 3]] :next])
              [:importing-sites [:import-sites 2] nil]))
       ;; second page of sites is imported
-      (is (= (reduce-job initial [:next [:success [:import-sites 1] [:continue [1 2 3]]]
+      (is (= (reduce-job initial [:next [:success [:import-sites 1] [:continue [1 2 3] 1]]
                                   :next [:success [:import-sites 2] [nil []]]])
              [:processing-facilities nil nil]))
 

--- a/test/planwise/model/import_job_test.clj
+++ b/test/planwise/model/import_job_test.clj
@@ -1,0 +1,110 @@
+(ns planwise.model.import-job-test
+  (:require [planwise.model.import-job :as sut]
+            [reduce-fsm :as fsm]
+            [clojure.test :refer :all]))
+
+
+(deftest push-task-test
+  (is (= [] (sut/push-task [] nil)))
+  (is (= [:foo] (sut/push-task [] :foo)))
+  (is (= [:foo] (sut/push-task [:foo] :foo)))
+  (is (= [:foo nil] (sut/push-task [:foo] nil)))
+  (is (= [:foo :bar] (sut/push-task [:foo] :bar)))
+  (is (= [:foo :bar :foo] (sut/push-task [:foo :bar] :foo))))
+
+(deftest peek-task-test
+  (is (nil? (sut/peek-task nil)))
+  (is (nil? (sut/peek-task [])))
+  (is (nil? (sut/peek-task [nil])))
+  (is (= :foo (sut/peek-task [:foo]))))
+
+(deftest remove-task-test
+  (is (= [] (sut/remove-task [] nil)))
+  (is (= [] (sut/remove-task [:foo] :foo)))
+  (is (= [] (sut/remove-task [:foo :foo] :foo)))
+  (is (= [:foo] (sut/remove-task [:foo] :bar))))
+
+(deftest task-report?-test
+  (is (false? (sut/task-report? nil)))
+  (is (true? (sut/task-report? [:success :import-types])))
+  (is (true? (sut/task-report? [:failure :import-types])))
+  (is (true? (sut/task-report? [:success [:process-facility [1]]])))
+  (is (false? (sut/task-report? :next)))
+  (is (false? (sut/task-report? :success))))
+
+(deftest last-task-report?-test
+  (is (true? (sut/last-task-report? [{:tasks []} [:success :import-types]])))
+  (is (true? (sut/last-task-report? [{:tasks [:import-types]} [:success :import-types]])))
+  (is (true? (sut/last-task-report? [{:tasks [:import-types]} [:failure :import-types]])))
+  (is (false? (sut/last-task-report? [{:tasks [:import-types]} [:success :other-task]])))
+  (is (false? (sut/last-task-report? [{:tasks [:process-facility [1]]}
+                                      [:success [:process-facility [2]]]]))))
+
+(deftest page-number-mismatch?-test
+  (is (true? (boolean (sut/page-number-mismatch? [{:page 1} [:success [:import-sites 2] [1 2 3]]])))))
+
+(deftest fsm-test
+  (letfn [(reduce-job [initial events]
+            (let [job (reduce fsm/fsm-event initial events)
+                  state (:state job)
+                  next-task (sut/job-peek-next-task job)
+                  result (sut/job-result job)]
+              [state next-task result]))]
+    (let [initial (sut/import-job)]
+      ;; initial task dispatched
+      (is (= (reduce-job initial [:next])         [:importing-types :import-types nil]))
+      ;; only one import types dispatched
+      (is (= (reduce-job initial [:next :next])   [:importing-types nil nil]))
+      ;; immediate user cancellation
+      (is (= (reduce-job initial [:cancel])       [:error nil :cancelled]))
+      ;; unexpected/invalid event
+      (is (= (reduce-job initial [:foo])          [:error nil :unexpected-event]))
+      ;; user cancels after the import types task was dispatched
+      (is (= (reduce-job initial [:next :cancel]) [:cancelling :import-types :cancelled]))
+
+      ;; user cancels while importing facility types
+      (is (= (reduce-job initial [:next
+                                  :cancel
+                                  [:success :import-types :new-types]
+                                  :next
+                                  [:success :update-projects]])
+             [:error nil :cancelled]))
+      (is (= (reduce-job initial [:next
+                                  :cancel
+                                  [:failure :import-types :some-error]
+                                  :next
+                                  [:failure :update-projects]])
+             [:error nil :cancelled]))
+
+      ;; failure to import facility types
+      (is (= (reduce-job initial [:next [:failure :import-types :some-error]])
+             [:error nil :import-types-failed]))
+
+      ;; facility types imported successfully
+      (is (= (reduce-job initial [:next [:success :import-types :new-types]])
+             [:request-sites nil nil])))
+
+    (let [initial (reduce fsm/fsm-event (sut/import-job) [:next [:success :import-types :new-types]])]
+      ;; first page of sites is requested
+      (is (= (reduce-job initial [:next])
+             [:importing-sites [:import-sites 1] nil]))
+      ;; single page of sites successfully imported
+      (is (= (reduce-job initial [:next [:success [:import-sites 1] [nil [1 2 3]]]])
+             [:processing-facilities nil nil]))
+      ;; page of sites successfully imported (continue)
+      (is (= (reduce-job initial [:next [:success [:import-sites 1] [:continue [1 2 3]]]])
+             [:request-sites nil nil]))
+      ;; page report mismatch
+      (is (= (reduce-job initial [:next [:success [:import-sites 2] [nil [1 2 3]]]])
+             [:error [:import-sites 1] :unexpected-event]))
+      ;; sites page is incremented
+      (is (= (reduce-job initial [:next [:success [:import-sites 1] [:continue [1 2 3]]] :next])
+             [:importing-sites [:import-sites 2] nil]))
+      ;; second page of sites is imported
+      (is (= (reduce-job initial [:next [:success [:import-sites 1] [:continue [1 2 3]]]
+                                  :next [:success [:import-sites 2] [nil []]]])
+             [:processing-facilities nil nil]))
+
+      ;; TODO: write tests for the rest of the flow
+      )
+    ))


### PR DESCRIPTION
Fixes #94. Closes #120.

Complete reimplementation of the importer component.

- The import job itself is now modelled with a FSM supporting cancellation in all stages.
- There's a TaskMaster asynchronous component which dispatches a configurable number of parallel tasks on demand.
- The job FSM handles task dispatching depending on the stage the import process is in.
- Fix import status handling on the client side as well, improving concurrency issues and closing #94.
- Progress report has been improved and will now report Resourcemap import progress as well as facility isochrones processing.
- Project updating is done as soon as the sites have been imported to improve project stats consistency during the import process.
- Last import operation result is shown in the UI.
- Other minor fixes and changes.

![import-job-fsm](https://cloud.githubusercontent.com/assets/733591/17750247/dede8cc2-6497-11e6-9ffd-51bd4ab18bb2.png)
