### PR TITLE
Load geojson by bounding box

### DIFF
--- a/resources/planwise/sql/facilities.sql
+++ b/resources/planwise/sql/facilities.sql
@@ -70,7 +70,7 @@ FROM facilities
   INNER JOIN facility_types ON facilities.type_id = facility_types.id
   LEFT OUTER JOIN facilities_polygons fp ON fp.facility_id = facilities.id AND fp.threshold = :threshold AND fp.method = :algorithm
 WHERE
-  ST_Intersects(fp.the_geom, ST_MakeEnvelope(:v*:bbox, 4326))
+  (fp.the_geom && ST_MakeEnvelope(:v*:bbox, 4326))
   :snip:criteria ;
 
 -- :name isochrone-for-facilities :? :1

--- a/scripts/dev
+++ b/scripts/dev
@@ -3,4 +3,8 @@ if [[ -e .env ]]; then
   source .env
 fi;
 
-(echo "(dev)"; echo "(go)"; cat <&0) | lein repl
+if $(which -s rlwrap); then
+  (echo "(dev)"; echo "(go)"; cat <&0) | rlwrap -r -m '\\"' -b "(){}[],^%3@\\\";:'" lein repl;
+else
+  (echo "(dev)"; echo "(go)"; cat <&0) | lein repl;
+fi;

--- a/src/leaflet/bboxloader.js
+++ b/src/leaflet/bboxloader.js
@@ -1,0 +1,219 @@
+goog.provide("leaflet.bboxloader");
+
+var throwFn = function(text) {
+  throw new Error(text);
+};
+
+L.Bounds.prototype.asLatLngBounds = function() {
+  var north = this.min.y,
+      west = this.min.x,
+      south = this.max.y,
+      east = this.max.x;
+
+  return L.latLngBounds(L.latLng(south, west),
+                        L.latLng(north, east));
+};
+
+L.LatLngBounds.prototype.asBounds = function() {
+  var top = this._northEast.lat,
+      right = this._northEast.lng,
+      bottom = this._southWest.lat,
+      left = this._southWest.lng;
+
+  return L.bounds(L.point(left, top),
+                  L.point(right, bottom));
+};
+
+L.GeoJSON.include({
+  asLayers: function(geojson, target) {
+    var features = L.Util.isArray(geojson) ? geojson : geojson.features,
+        layers = target || [],
+        i, len, feature;
+
+    if (features) {
+      for (i = 0, len = features.length; i < len; i++) {
+        // Only add this if geometry or geometries are set and not null
+        feature = features[i];
+        if (feature.geometries || feature.geometry || feature.features || feature.coordinates) {
+          this.asLayers(features[i], layers);
+        }
+      }
+      return layers;
+    }
+
+    var options = this.options;
+
+    if (options.filter && !options.filter(geojson)) { return; }
+
+    var layer = L.GeoJSON.geometryToLayer(geojson, options.pointToLayer, options.coordsToLatLng, options);
+    layer.feature = L.GeoJSON.asFeature(geojson);
+
+    layer.defaultOptions = layer.options;
+    this.resetStyle(layer);
+
+    if (options.onEachFeature) {
+      options.onEachFeature(geojson, layer);
+    }
+
+    layers.push(layer);
+    return layers;
+  }
+});
+
+
+L.BBoxLoader = L.Class.extend({
+
+  initialize: function(options) {
+    this._callback = options.callback || throwFn("'callback' is required");
+    this._layer = options.layer || throwFn("'layer' is required");
+    this._levels = options.levels || throwFn("'levels' is required");
+    this._idFn = options.idFn || function(x) { return x.id; };
+    this._featureFn = options.featureFn || function(x) { return x; };
+
+    this._featuresCurrentLevel = {}; // id -> level
+
+    this._tileCache = {};
+    this._featureCache = {}; // level -> id -> [feature]
+
+    for (levelKey in this._levels) {
+      this._tileCache[levelKey] = {};
+      this._featureCache[levelKey] = {};
+    };
+  },
+
+  onAdd: function(map) {
+    this._map = map;
+    map.on({
+      'viewreset': this._reset,
+      'moveend': this._update
+    }, this);
+
+    map.addLayer(this._layer);
+    this._update();
+    return this;
+  },
+
+  onRemove: function(map) {
+    map.removeLayer(this._layer);
+  },
+
+  addFeature: function(level, featureId, newFeatures) {
+    var self = this;
+
+    // If the feature is currently displayed at a lower zoom level than
+    // the desired one, or isn't displayed at all, replace it in the layer
+    var featureCurrentLevel = this._featuresCurrentLevel[featureId];
+    if (featureCurrentLevel && featureCurrentLevel >= level) return;
+
+    var oldFeatures = null;
+    if (featureCurrentLevel) {
+      oldFeatures = this._featureCache[featureCurrentLevel][featureId];
+    }
+
+    newFeatures = L.Util.isArray(newFeatures) ? newFeatures : [newFeatures];
+    newFeatures.forEach(function(f) {
+      self._layer.addLayer(f);
+    });
+
+    this._featureCache[level][featureId] = newFeatures;
+    this._featuresCurrentLevel[featureId] = level;
+
+    if (oldFeatures) {
+      oldFeatures.forEach(function(f) {
+        self._layer.removeLayer(oldFeatures);
+      });
+    }
+
+    return this;
+  },
+
+  _update: function() {
+    if (!this._map)
+      return;
+
+    var level = this._getCurrentLevel(),
+        map = this._map,
+        bounds = map.getBounds().pad(0.5).asBounds(),
+        tileSize = this._levels[level].tileSize || throwFn("Tile size not set for level " + level),
+        tileIndices = L.bounds(
+          bounds.min.divideBy(tileSize)._floor(),
+          bounds.max.divideBy(tileSize)._floor());
+
+    this._addTiles(level, tileSize, tileIndices);
+  },
+
+  _reset: function() {
+  },
+
+  _getCurrentLevel: function() {
+    var map = this._map || throwFn("Cannot get current level unattached to a map"),
+        level = this._map.getZoom();
+
+    for(levelKey in this._levels) {
+      var lb = this._levels[levelKey].lb,
+          ub = this._levels[levelKey].ub;
+      if ((!lb || level >= lb) && (!ub || level < ub)) {
+        return levelKey;
+      }
+    }
+
+    throw new Error("Could not determine layer level for map level " + level);
+  },
+
+  _addTiles: function(level, tileSize, tileIndices) {
+    var self = this;
+
+    // Check if any tile within the bbox requires to be loaded
+    var bounds = L.bounds([]);
+    for (var j = tileIndices.min.y; j <= tileIndices.max.y; j++) {
+      for (var i = tileIndices.min.x; i <= tileIndices.max.x; i++) {
+        var tileKey = (i + ":" + j + ":" + level);
+        if (!this._tileCache[tileKey]) {
+          bounds.extend(L.point(i, j));
+          this._tileCache[tileKey] = true; // Mark as requested
+        }
+      }
+    }
+
+    if (!bounds.isValid()) {
+      return;
+    }
+
+    // Map tile indices bounds to actual latlng bounds
+    var latLngBounds = L.bounds(
+                         bounds.min.multiplyBy(tileSize),
+                         bounds.max.add(L.point(1,1)).multiplyBy(tileSize)
+                       ).asLatLngBounds();
+
+    // Retrieve what features have been already loaded for the current level or greater
+    var loadedFeatures = [];
+    for (var featureId in this._featuresCurrentLevel) {
+      var featureLevel = this._featuresCurrentLevel[featureId];
+      if (featureLevel >= level) {
+        loadedFeatures.push(featureId);
+      }
+    }
+
+    // Issue callback to request features
+    this._callback(level, latLngBounds.toBBoxString(), loadedFeatures, function(newFeatures) {
+      if (newFeatures.length > 0) {
+        console.log("Loading " + newFeatures.length + " new features on level " + level);
+      }
+      newFeatures.forEach(function(f) {
+        var newFeature = self._featureFn(f) || throwFn("Could not retrieve feature"),
+            featureId = self._idFn(f) || throwFn("Could not retrieve id for feature");
+        // If feature is actually plain geojson data, pass it through asLayers before adding it as a feature
+        if (typeof(newFeature.onAdd) !== "function" && typeof(self._layer.asLayers) === "function") {
+          newFeature = self._layer.asLayers(newFeature);
+        }
+        self.addFeature(level, featureId, newFeature);
+      });
+    });
+  }
+});
+
+L.bboxLoader = function(options) {
+  return new L.BBoxLoader(options);
+};
+
+leaflet.bboxloader = L.bboxLoader;

--- a/src/leaflet/bboxloader.js
+++ b/src/leaflet/bboxloader.js
@@ -70,15 +70,7 @@ L.BBoxLoader = L.Class.extend({
     this._idFn = options.idFn || function(x) { return x.id; };
     this._featureFn = options.featureFn || function(x) { return x; };
 
-    this._featuresCurrentLevel = {}; // id -> level
-
-    this._tileCache = {};
-    this._featureCache = {}; // level -> id -> [feature]
-
-    for (levelKey in this._levels) {
-      this._tileCache[levelKey] = {};
-      this._featureCache[levelKey] = {};
-    };
+    this._initCaches();
   },
 
   onAdd: function(map) {
@@ -95,6 +87,14 @@ L.BBoxLoader = L.Class.extend({
 
   onRemove: function(map) {
     map.removeLayer(this._layer);
+    map.off({
+      'viewreset': this._reset,
+      'moveend': this._update
+    }, this);
+    this._map = null;
+    this._initCaches();
+
+    return this;
   },
 
   addFeature: function(level, featureId, newFeatures) {
@@ -125,6 +125,16 @@ L.BBoxLoader = L.Class.extend({
     }
 
     return this;
+  },
+
+  _initCaches: function() {
+    this._featuresCurrentLevel = {}; // id -> level
+    this._tileCache = {}; // key -> bool
+    this._featureCache = {}; // level -> id -> [feature]
+    for (levelKey in this._levels) {
+      this._tileCache[levelKey] = {};
+      this._featureCache[levelKey] = {};
+    };
   },
 
   _update: function() {

--- a/src/leaflet/core.cljs
+++ b/src/leaflet/core.cljs
@@ -32,9 +32,13 @@
            new-objects []
            new-decls new-decls]
 
-      (let [old-decl (first old-decls)
-            new-decl (first new-decls)]
-        (if (or old-decl new-decl)
+      (if (and (empty? old-decls) (empty? new-decls))
+        ;; done iterating over the declarations
+        new-objects
+
+        ;; replace declaration
+        (let [old-decl (first old-decls)
+              new-decl (first new-decls)]
           (let [old-object (first old-objects)
                 new-object (replace-object old-object old-decl new-decl)]
 
@@ -42,11 +46,7 @@
             (recur (rest old-objects)
                    (rest old-decls)
                    (conj new-objects new-object)
-                   (rest new-decls)))
-
-          ;; done iterating over the declarations
-          new-objects)))))
-
+                   (rest new-decls))))))))
 
 (defn create-marker [point {:keys [lat-fn lon-fn icon-fn popup-fn], :or {lat-fn :lat lon-fn :lon}}]
   (let [latLng (.latLng js/L (lat-fn point) (lon-fn point))

--- a/src/leaflet/core.cljs
+++ b/src/leaflet/core.cljs
@@ -1,5 +1,7 @@
 (ns leaflet.core
-  (:require [reagent.core :as reagent :refer [atom]]
+  (:require [leaflet.geojsongroup]
+            [leaflet.bboxloader]
+            [reagent.core :as reagent :refer [atom]]
             [reagent.debug :as debug]
             [clojure.data :as data]))
 

--- a/src/leaflet/geojsongroup.js
+++ b/src/leaflet/geojsongroup.js
@@ -1,3 +1,5 @@
+goog.provide("leaflet.geojsongroup");
+
 // Modify L.Path to check for _pathGroup before _map in all relevant methods
 // Instead of adding/removing itself from a _map, do it from its _pathGroup
 L.Path.include({
@@ -189,3 +191,5 @@ L.geoJson.group = function (geojson, options) {
 L.pathGroup = function(options) {
   return new L.PathGroup(options);
 };
+
+leaflet.geojsongroup = L.geoJson.group;

--- a/src/planwise/boundary/facilities.clj
+++ b/src/planwise/boundary/facilities.clj
@@ -20,6 +20,13 @@
     threshold (in seconds) calculated using algorithm and simplified according
     to the given parameter.")
 
+  (isochrones-in-bbox
+    [this isochrone-options facilities-criteria]
+    "Returns the isochrones present in the :bbox specified in the criteria param,
+     returning only isochrone, id and polygon-id. An :excluding parameter can be
+     also provided; for such facilities the isochrones will not be returned,
+     yet their id will still be returned.")
+
   (isochrone-all-facilities
     [this threshold]
     "Retrieve the catchment area for all facilities available for the given
@@ -49,5 +56,7 @@
      (service/list-with-isochrones service isochrone-options facilities-criteria)))
   (isochrone-all-facilities [service threshold]
     (service/get-isochrone-for-all-facilities service threshold))
+  (isochrones-in-bbox [service isochrone-options facilities-criteria]
+    (service/isochrones-in-bbox service isochrone-options facilities-criteria))
   (list-types [service]
     (service/list-types service)))

--- a/src/planwise/client/api.cljs
+++ b/src/planwise/client/api.cljs
@@ -57,7 +57,7 @@
      :error-handler error-handler}))
 
 (defn json-request [params fns & keyargs]
-  (assoc (raw-request params fns keyargs)
+  (assoc (apply raw-request params fns keyargs)
     :format :json
     :response-format :json
     :keywords? true))

--- a/src/planwise/client/mapping.cljs
+++ b/src/planwise/client/mapping.cljs
@@ -26,9 +26,9 @@
                 :accessToken mapbox-access-token}])
 
 (def geojson-levels
-  {1 {:ub 9, :simplify 0.4, :tileSize 2.0}
-   2 {:lb 9, :ub 13, :simplify 0.1, :tileSize 1.0}
-   3 {:lb 13, :simplify 0.0, :tileSize 0.5}})
+  {1 {:ub 8, :simplify 0.1, :tileSize 10.0}
+   2 {:lb 8, :ub 11, :simplify 0.01, :tileSize 2.0}
+   3 {:lb 11, :simplify 0.0, :tileSize 1.0}})
 
 (def geojson-first-level
   (-> geojson-levels keys first))

--- a/src/planwise/client/mapping.cljs
+++ b/src/planwise/client/mapping.cljs
@@ -1,5 +1,6 @@
 (ns planwise.client.mapping
-  (:require [reagent.format :as fmt]))
+  (:require [reagent.format :as fmt]
+            [re-frame.utils :as c]))
 
 (def mapbox-tile-url "http://api.tiles.mapbox.com/v4/{mapid}/{z}/{x}/{y}.png?access_token={accessToken}")
 (def mapbox-mapid "ggiraldez.056e1919")
@@ -23,6 +24,25 @@
                 :maxZoom 18
                 :mapid gray-mapbox-mapid
                 :accessToken mapbox-access-token}])
+
+(def geojson-levels
+  {1 {:ub 9, :simplify 0.4, :tileSize 2.0}
+   2 {:lb 9, :ub 13, :simplify 0.1, :tileSize 1.0}
+   3 {:lb 13, :simplify 0.0, :tileSize 0.5}})
+
+(def geojson-first-level
+  (-> geojson-levels keys first))
+
+(defn geojson-level->simplify
+  [level]
+  (get-in geojson-levels [(js/parseInt level) :simplify]))
+
+(defn simplify->geojson-level
+  [simplify]
+  (->> geojson-levels
+    (filter (fn [[level {s :simplify}]] (= s simplify)))
+    (map first)
+    first))
 
 (defn static-image [geojson]
   (fmt/format "https://api.mapbox.com/v4/%s/geojson(%s)/auto/256x144.png?access_token=%s"

--- a/src/planwise/client/projects/api.cljs
+++ b/src/planwise/client/projects/api.cljs
@@ -1,6 +1,7 @@
 (ns planwise.client.projects.api
   (:require [ajax.core :refer [GET POST PUT DELETE]]
-            [planwise.client.api :refer [json-request]]))
+            [planwise.client.api :refer [json-request]]
+            [re-frame.utils :as c]))
 
 (defn- process-filters [filters]
   ; TODO: Make the set->vector conversion generic and move it into an interceptor
@@ -39,7 +40,10 @@
 (defn fetch-facilities-with-isochrones [filters isochrone-options & handlers]
   (GET
     "/api/facilities/with-isochrones"
-    (json-request (merge isochrone-options (process-filters filters)) handlers)))
+    (json-request
+      (merge isochrone-options (process-filters filters))
+      handlers
+      :mapper-fn (partial merge isochrone-options))))
 
 (defn fetch-facility-types [& handlers]
   (GET "/api/facilities/types" (json-request {} handlers)))
@@ -49,4 +53,8 @@
         params {:id project-id
                 :filters filters
                 :with (some-> with-data name)}]
-    (PUT url (json-request params handlers))))
+    (PUT url
+      (json-request
+        params
+        handlers
+        :mapper-fn (partial merge (dissoc filters :facilities))))))

--- a/src/planwise/client/projects/api.cljs
+++ b/src/planwise/client/projects/api.cljs
@@ -46,7 +46,7 @@
       :mapper-fn (partial merge isochrone-options))))
 
 (defn fetch-isochrones-in-bbox [filters isochrone-options & handlers]
-  (GET
+  (POST
     "/api/facilities/bbox-isochrones"
     (json-request
       (merge isochrone-options (process-filters filters))

--- a/src/planwise/client/projects/api.cljs
+++ b/src/planwise/client/projects/api.cljs
@@ -45,6 +45,14 @@
       handlers
       :mapper-fn (partial merge isochrone-options))))
 
+(defn fetch-isochrones-in-bbox [filters isochrone-options & handlers]
+  (GET
+    "/api/facilities/bbox-isochrones"
+    (json-request
+      (merge isochrone-options (process-filters filters))
+      handlers
+      :mapper-fn (partial merge isochrone-options))))
+
 (defn fetch-facility-types [& handlers]
   (GET "/api/facilities/types" (json-request {} handlers)))
 

--- a/src/planwise/client/projects/handlers.cljs
+++ b/src/planwise/client/projects/handlers.cljs
@@ -169,7 +169,7 @@
    (let [level (maps/simplify->geojson-level simplify)
          isochrones  (->> facilities
                        (filter #(some? (:isochrone %)))
-                       (map (juxt :id #(js/JSON.parse (:isochrone %))))
+                       (map (juxt :id (comp js/JSON.parse :isochrone)))
                        (flatten)
                        (apply hash-map))]
      (-> db

--- a/src/planwise/client/projects/handlers.cljs
+++ b/src/planwise/client/projects/handlers.cljs
@@ -205,7 +205,7 @@
     (let [new-db (assoc-in db [:transport :time] time)
           filters (db/project-filters new-db)
           project-id (get-in db [:project-data :id])]
-      (api/update-project project-id filters :facilities-with-demand
+      (api/update-project project-id filters nil
                           :projects/project-updated)
       new-db)))
 

--- a/src/planwise/client/projects/subs.cljs
+++ b/src/planwise/client/projects/subs.cljs
@@ -44,6 +44,13 @@
         :filter-stats (select-keys @facility-data [:count :total])
         :facilities (:list @facility-data))))))
 
+; REFACTOR: Simplify constant is duplicated here as well
+(register-sub
+ :projects/isochrones
+ (fn [db [_ data]]
+   (let [transport-time (subscribe [:projects/transport-time])]
+     (reaction (vec (vals (get-in @db [:projects :current :facilities :isochrones @transport-time 0.4])))))))
+
 (register-sub
  :projects/transport-time
  (fn [db [_]]

--- a/src/planwise/client/projects/subs.cljs
+++ b/src/planwise/client/projects/subs.cljs
@@ -44,12 +44,10 @@
         :filter-stats (select-keys @facility-data [:count :total])
         :facilities (:list @facility-data))))))
 
-; REFACTOR: Simplify constant is duplicated here as well
 (register-sub
- :projects/isochrones
- (fn [db [_ data]]
-   (let [transport-time (subscribe [:projects/transport-time])]
-     (reaction (vec (vals (get-in @db [:projects :current :facilities :isochrones @transport-time 0.4])))))))
+ :projects/facilities-criteria
+ (fn [db [_]]
+   (reaction (db/facilities-criteria (get-in @db [:projects :current])))))
 
 (register-sub
  :projects/transport-time

--- a/src/planwise/client/projects/views.cljs
+++ b/src/planwise/client/projects/views.cljs
@@ -34,7 +34,7 @@
 
 (defn- project-tab [project-id project-region-id selected-tab]
   (let [facilities (subscribe [:projects/facilities :facilities])
-        isochrones (subscribe [:projects/facilities :isochrones])
+        isochrones (subscribe [:projects/isochrones])
         map-position (subscribe [:projects/map-view :position])
         map-zoom (subscribe [:projects/map-view :zoom])
         map-bbox (subscribe [:projects/map-view :bbox])

--- a/src/planwise/client/projects/views.cljs
+++ b/src/planwise/client/projects/views.cljs
@@ -1,11 +1,15 @@
 (ns planwise.client.projects.views
-  (:require [re-frame.core :refer [subscribe dispatch]]
+  (:require-macros [reagent.ratom :refer [reaction]])
+  (:require [re-frame.core :refer [subscribe dispatch dispatch-sync]]
             [re-com.core :as rc]
+            [re-frame.utils :as c]
             [clojure.string :as str]
             [leaflet.core :refer [map-widget]]
             [planwise.client.mapping :as mapping]
             [planwise.client.config :as config]
             [planwise.client.styles :as styles]
+            [planwise.client.projects.api :as api]
+            [planwise.client.projects.db :as db]
             [planwise.client.components.common :as common]
             [planwise.client.projects.components.new-project
              :refer [new-project-dialog]]
@@ -15,6 +19,29 @@
              :refer [header-section]]
             [planwise.client.projects.components.sidebar
              :refer [sidebar-section]]))
+
+(defn geojson-bbox-callback [isochrones filters threshold]
+  (fn [level bounds bbox-excluding callback]
+    (let [level (js/parseInt level)
+          bbox-excluding (map #(js/parseInt %) bbox-excluding)
+          cache-existing (keys (get-in @isochrones [threshold level]))]
+      (api/fetch-isochrones-in-bbox
+        @filters
+        {:threshold threshold,
+         :bbox bounds,
+         :excluding (str/join "," cache-existing)
+         :simplify (mapping/geojson-level->simplify level)}
+        (fn [response]
+          (dispatch-sync [:projects/isochrones-loaded response])
+          (let [isochrones-for-level (get-in @isochrones [threshold level])
+                new-isochrones (->> response
+                                  (:facilities)
+                                  (map :id)
+                                  (remove (set bbox-excluding))
+                                  (select-keys isochrones-for-level)
+                                  (map (fn [[id isochrone]] {:id id, :isochrone isochrone}))
+                                  (vec))]
+            (callback (clj->js new-isochrones))))))))
 
 (defn project-list-page []
   (let [view-state (subscribe [:projects/view-state])
@@ -34,13 +61,17 @@
 
 (defn- project-tab [project-id project-region-id selected-tab]
   (let [facilities (subscribe [:projects/facilities :facilities])
-        isochrones (subscribe [:projects/isochrones])
         map-position (subscribe [:projects/map-view :position])
         map-zoom (subscribe [:projects/map-view :zoom])
         map-bbox (subscribe [:projects/map-view :bbox])
         demand-map-key (subscribe [:projects/demand-map-key])
         map-geojson (subscribe [:projects/map-geojson])
-        marker-popup-fn #(str (:name %) "<br/>" (:type %))]
+        marker-popup-fn #(str (:name %) "<br/>" (:type %))
+        isochrones (subscribe [:projects/facilities :isochrones])
+        project-facilities-criteria (subscribe [:projects/facilities-criteria])
+        project-transport-time (subscribe [:projects/transport-time])
+        callback-fn (reaction (geojson-bbox-callback isochrones project-facilities-criteria @project-transport-time))
+        feature-fn #(aget % "isochrone")]
 
     (fn [project-id project-region-id selected-tab]
       (cond
@@ -86,16 +117,15 @@
                                    :fillOpacity 0.1
                                    :weight 0}])
                 ;; Isochrone for selected transport
-                (when (and (seq @isochrones) (= :transport selected-tab))
-                  [:geojson-layer {:data @isochrones
-                                   :fillOpacity 1
-                                   :weight 2
-                                   :color styles/green
-                                   :group {:opacity 0.4}}])]
+                (when (= :transport selected-tab)
+                  [:geojson-bbox-layer { :levels mapping/geojson-levels
+                                         :fillOpacity 1
+                                         :weight 2
+                                         :color styles/green
+                                         :group {:opacity 0.4}
+                                         :featureFn feature-fn
+                                         :callback @callback-fn}])])]]
 
-               ;; Filter out nils so leaflet/map-widget doesn't get confused
-               (filter some?)
-               vec)]]
         (= :scenarios selected-tab)
         [:div
          [:h1 "Scenarios"]]))))

--- a/src/planwise/client/projects/views.cljs
+++ b/src/planwise/client/projects/views.cljs
@@ -39,8 +39,7 @@
                                   (map :id)
                                   (remove (set bbox-excluding))
                                   (select-keys isochrones-for-level)
-                                  (map (fn [[id isochrone]] {:id id, :isochrone isochrone}))
-                                  (vec))]
+                                  (mapv (fn [[id isochrone]] {:id id, :isochrone isochrone})))]
             (callback (clj->js new-isochrones))))))))
 
 (defn project-list-page []

--- a/src/planwise/component/facilities.clj
+++ b/src/planwise/component/facilities.clj
@@ -19,8 +19,11 @@
   [component]
   (get-in component [:db :spec]))
 
-(defn facilities-criteria [criteria]
-  (criteria-snip criteria))
+(defn- isochrone-params [{:keys [threshold algorithm simplify]}]
+  {:threshold (or threshold 900)
+   :algorithm (or algorithm "alpha-shape")
+   :simplify  (or simplify 0.001)})
+
 
 ;; ----------------------------------------------------------------------
 ;; Service definition
@@ -51,29 +54,34 @@
   ([service criteria]
    (facilities-by-criteria
      (get-db service)
-     {:criteria (facilities-criteria criteria)})))
+     {:criteria (criteria-snip criteria)})))
 
 (defn count-facilities
   ([service]
    (count-facilities service {}))
   ([service criteria]
    (let [db (get-db service)
-         criteria (facilities-criteria criteria)
+         criteria (criteria-snip criteria)
          result (count-facilities-by-criteria db {:criteria criteria})]
      (:count result))))
 
 (defn list-with-isochrones
   ([service]
    (list-with-isochrones service {} {}))
-  ([service isochrone-options]
-   (list-with-isochrones service isochrone-options {}))
-  ([service {:keys [threshold algorithm simplify]} criteria]
+  ([service isochrone-opts]
+   (list-with-isochrones service isochrone-opts {}))
+  ([service isochrone-opts criteria]
    (facilities-with-isochrones (get-db service)
-      {:threshold (or threshold 900)
-       :algorithm (or algorithm "alpha-shape")
-       :simplify  (or simplify 0.001)
+     (assoc (isochrone-params isochrone-opts)
        :region    (:region criteria)
-       :criteria  (facilities-criteria criteria)})))
+       :criteria  (criteria-snip criteria)))))
+
+(defn isochrones-in-bbox
+  ([service isochrone-opts criteria]
+   (isochrones-in-bbox* (get-db service)
+     (-> (isochrone-params isochrone-opts)
+        (merge (select-keys criteria [:bbox :excluding]))
+        (assoc :criteria (criteria-snip criteria))))))
 
 (defn get-isochrone-for-all-facilities [service threshold]
   (isochrone-for-facilities (get-db service) {:threshold threshold}))

--- a/src/planwise/endpoint/facilities.clj
+++ b/src/planwise/endpoint/facilities.clj
@@ -8,15 +8,26 @@
             [ring.util.response :refer [response]]))
 
 (defn- facilities-criteria [{:keys [type region bbox excluding]}]
-  {:region (when region (Integer. region))
-   :types (when type (map #(Integer. %) (if (map? type) (vals type) type)))
-   :bbox (when bbox (map #(Float. %) (string/split bbox #",")))
-   :excluding (when-not (string/blank? excluding) (map #(Integer. %) (string/split excluding #",")))})
+  {:region (some-> region Integer.)
+   :types (when type
+            (map
+              #(Integer. %)
+              (if (map? type)
+                (vals type)
+                type)))
+   :bbox (when bbox
+           (map
+            #(Float. %)
+            (string/split bbox #",")))
+   :excluding (when-not (string/blank? excluding)
+                (map
+                  #(Integer. %)
+                  (string/split excluding #",")))})
 
 (defn- isochrone-criteria [{:keys [threshold algorithm simplify]}]
-  {:threshold (when threshold (Integer. threshold))
+  {:threshold (some-> threshold Integer.)
    :algorithm algorithm
-   :simplify (when simplify (Float. (str simplify)))})
+   :simplify (some-> simplify str Float.)})
 
 (defn- endpoint-routes [service maps-service]
   (routes

--- a/src/planwise/endpoint/facilities.clj
+++ b/src/planwise/endpoint/facilities.clj
@@ -9,14 +9,14 @@
 
 (defn- facilities-criteria [{:keys [type region bbox excluding]}]
   {:region (when region (Integer. region))
-   :types (when type (map #(Integer. %) (vals type)))
+   :types (when type (map #(Integer. %) (if (map? type) (vals type) type)))
    :bbox (when bbox (map #(Float. %) (string/split bbox #",")))
    :excluding (when-not (string/blank? excluding) (map #(Integer. %) (string/split excluding #",")))})
 
 (defn- isochrone-criteria [{:keys [threshold algorithm simplify]}]
-  {:threshold (Integer. threshold)
+  {:threshold (when threshold (Integer. threshold))
    :algorithm algorithm
-   :simplify (if simplify (Float. simplify) nil)})
+   :simplify (when simplify (Float. (str simplify)))})
 
 (defn- endpoint-routes [service maps-service]
   (routes
@@ -43,7 +43,7 @@
          (assoc demand
                 :facilities facilities))))
 
-   (GET "/bbox-isochrones" [& params]
+   (ANY "/bbox-isochrones" [& params]
      (let [criteria   (facilities-criteria params)
            isochrone  (isochrone-criteria params)
            facilities (facilities/isochrones-in-bbox service isochrone criteria)]

--- a/src/planwise/endpoint/home.clj
+++ b/src/planwise/endpoint/home.clj
@@ -54,6 +54,7 @@
       (client-config (assoc endpoint :request request))
       (include-js "/assets/leaflet/leaflet.js")
       (include-js "/js/leaflet.geojsongroups.js")
+      (include-js "/js/leaflet.bboxloader.js")
       (include-js "/js/main.js")
       [:script "planwise.client.core.main();"]])))
 

--- a/src/planwise/endpoint/home.clj
+++ b/src/planwise/endpoint/home.clj
@@ -53,8 +53,6 @@
       (anti-forgery-field)
       (client-config (assoc endpoint :request request))
       (include-js "/assets/leaflet/leaflet.js")
-      (include-js "/js/leaflet.geojsongroups.js")
-      (include-js "/js/leaflet.bboxloader.js")
       (include-js "/js/main.js")
       [:script "planwise.client.core.main();"]])))
 

--- a/src/planwise/endpoint/projects.clj
+++ b/src/planwise/endpoint/projects.clj
@@ -21,7 +21,8 @@
         (assoc project :facilities project-facilities))
       :isochrones
       (let [time       (get-in project [:filters :transport :time])
-            options    {:threshold time}
+            simplify   (get-in project [:filters :simplify])
+            options    {:threshold time, :simplify simplify}
             isochrones (when time
                          (facilities/list-with-isochrones facilities options criteria))
             demand     (when isochrones

--- a/src/planwise/endpoint/projects.clj
+++ b/src/planwise/endpoint/projects.clj
@@ -19,17 +19,16 @@
       :facilities
       (let [project-facilities (facilities/list-facilities facilities criteria)]
         (assoc project :facilities project-facilities))
-      :isochrones
-      (let [time       (get-in project [:filters :transport :time])
-            simplify   (get-in project [:filters :simplify])
-            options    {:threshold time, :simplify simplify}
+      :facilities-with-demand
+      (let [project-facilities (facilities/list-facilities facilities criteria)
+            time       (get-in project [:filters :transport :time])
             isochrones (when time
-                         (facilities/list-with-isochrones facilities options criteria))
+                         []) ; TODO: Load isochrones to calculate demand
             demand     (when isochrones
                          (maps/demand-map maps (:region-id project) isochrones))]
         (-> project
-          (assoc :isochrones isochrones)
-          (merge demand)))
+          (merge demand)
+          (assoc :facilities project-facilities)))
       project)))
 
 (defn- endpoint-routes

--- a/src/planwise/system.clj
+++ b/src/planwise/system.clj
@@ -11,6 +11,7 @@
             [ring.component.jetty :refer [jetty-server]]
             [ring.middleware.resource :refer [wrap-resource]]
             [ring.middleware.defaults :refer [wrap-defaults api-defaults site-defaults]]
+            [ring.middleware.keyword-params :refer [wrap-keyword-params]]
             [ring.middleware.json :refer [wrap-json-response wrap-json-params]]
             [ring.middleware.gzip :refer [wrap-gzip]]
             [ring.middleware.webjars :refer [wrap-webjars]]
@@ -90,6 +91,7 @@
           :jwe-options jwe-options}
    :api {:middleware   [[wrap-authorization :auth-backend]
                         [wrap-authentication :session-auth-backend :jwe-auth-backend]
+                        [wrap-keyword-params]
                         [wrap-json-params]
                         [wrap-json-response]
                         [wrap-defaults :api-defaults]]

--- a/test/planwise/component/facilities_test.clj
+++ b/test/planwise/component/facilities_test.clj
@@ -15,7 +15,7 @@
     [{:id 1 :name "Facility A" :type_id 1 :lat -3   :lon 42 :the_geom (make-point -3 42)}
      {:id 2 :name "Facility B" :type_id 1 :lat -3.5 :lon 42 :the_geom (make-point -3.5 42)}]]
    [:facilities_polygons
-    [{:facility_id 1 :threshold 900 :method "alpha-shape" :the_geom (sample-polygon)}]]])
+    [{:id 1 :facility_id 1 :threshold 900 :method "alpha-shape" :the_geom (sample-polygon)}]]])
 
 (def new-facilities
   [{:id 3 :name "New facility" :type_id 1 :lat 4 :lon 10 :type "hospital"}])
@@ -50,3 +50,23 @@
     (let [service (:facilities system)]
       (facilities/destroy-facilities! service)
       (is (= 0 (count (facilities/list-facilities service)))))))
+
+(deftest list-isochrones-in-bbox
+  (with-system (system)
+    (let [service (:facilities system)
+          facilities (facilities/isochrones-in-bbox service {:threshold 900} {:bbox [0.0 0.0 2.0 2.0]})]
+      (is (= 1 (count facilities)))
+      (let [[facility] facilities]
+        (is (= 1 (:id facility)))
+        (is (= 1 (:polygon-id facility)))
+        (is (:isochrone facility))))))
+
+(deftest list-isochrones-in-bbox-excluding-ids
+  (with-system (system)
+    (let [service (:facilities system)
+          facilities (facilities/isochrones-in-bbox service {:threshold 900} {:bbox [0.0 0.0 2.0 2.0], :excluding [1]})]
+      (is (= 1 (count facilities)))
+      (let [[facility] facilities]
+        (is (= 1 (:id facility)))
+        (is (= 1 (:polygon-id facility)))
+        (is (nil? (:isochrone facility)))))))


### PR DESCRIPTION
Add bbox-loader leaflet component that manages the features of a layer group (in this case, a geojson group layer) by requesting them by bounding box and level, from a supplied callback. The loader keeps track of the _tiles_ already requested, to minimise the number of requests. The _level_ is inferred from the current map zoom level, and it is responsibility of its client to decide the resolution of the features provided by level.

Additionally, the client _db_ keeps track of the isochrones loaded by threshold, level and facility-id. When the bbox-loader requests the features for a bbox, it will make a request to a new endpoint on the server, with the bbox and the ids of the isochrones already loaded. The server will answer with all isochrones in the bbox that are not in the set of already loaded ids, so as to reduce bandwidth.

This has the side effect of caching the isochrones for different thresholds in the client _db_, so switching back to a threshold within a project will not re-download all isochrones from the server (it will make a request though, answered by the server with the list of facilities, yet with no isochrones).

As a further optimisation, the client could also keep track of the features by bounding box, or the set of tiles already requested, and only make the request to the server if there are new tiles needed.

Fixes #139 
Fixes #78 