### PR TITLE
Update map view only if position changed in leaflet wrapper

### DIFF
--- a/src/leaflet/core.cljs
+++ b/src/leaflet/core.cljs
@@ -185,8 +185,7 @@
         (if (and children-to-fit-changed any-children-to-fit)
           (let [feature-group-to-fit (reduce #(.addLayer %1 %2) (.featureGroup js/L) layers-to-fit)
                 bounds (.getBounds feature-group-to-fit)]
-            (.fitBounds leaflet bounds)
-            (leaflet-moveend-handler this))))
+            (.fitBounds leaflet bounds))))
 
       ;; update component state
       (reagent/set-state this {:layers new-layers
@@ -198,8 +197,10 @@
         position (:position props)
         zoom (:zoom props)
         leaflet (:map state)]
-    (reagent/set-state this {:position position :zoom zoom})
-    (.setView leaflet (clj->js position) zoom)))
+    (if (or (not= position (:position state)) (not= zoom (:zoom state)))
+      (do
+        (reagent/set-state this {:position position :zoom zoom})
+        (.setView leaflet (clj->js position) zoom)))))
 
 (defn leaflet-update-options [this]
   (let [state (reagent/state this)


### PR DESCRIPTION
Check if the map position/zoom state changed w.r.t. the component's props, and only run a setView if there was indeed a change.

Fixes issues with setBounds calls combined with a callback that set the position/zoom as a prop on every moveend.

Fix #118