### PR TITLE
Refactor client's project viewmodel

### DIFF
--- a/src/planwise/client/current_project/api.cljs
+++ b/src/planwise/client/current_project/api.cljs
@@ -16,11 +16,7 @@
         params {:id project-id
                 :filters filters
                 :with (some-> with-data name)}]
-    (PUT url
-        (json-request
-         params
-         handlers
-         :mapper-fn (partial merge (dissoc filters :facilities))))))
+    (PUT url (json-request params handlers))))
 
 ;; Dataset related APIs
 
@@ -31,11 +27,11 @@
 ;; Facilities related APIs
 
 (defn- process-filters [filters]
-  ;; TODO: Make the set->vector conversion generic and move it into an interceptor
-  (let [processed-filters (into {} (for [[k v] filters] [k (if (set? v) (apply vector v) v)]))]
-    (if (seq (:type filters))
-      processed-filters
-      (assoc processed-filters :type ""))))
+  "Force the presence of the type filter in case there is none selected,
+  otherwise the server will not filter by type altogether"
+  (if (seq (:type filters))
+    filters
+    (assoc filters :type "")))
 
 (defn fetch-facilities [filters & handlers]
   (GET

--- a/src/planwise/client/current_project/api.cljs
+++ b/src/planwise/client/current_project/api.cljs
@@ -1,0 +1,52 @@
+(ns planwise.client.current-project.api
+  (:require [ajax.core :refer [GET POST PUT]]
+            [planwise.client.api :refer [json-request]]))
+
+
+;; Project loading and updating
+
+(defn load-project [id with-data & handlers]
+  (let [url (str "/api/projects/" id)
+        params {:id id
+                :with (some-> with-data name)}]
+    (GET url (json-request params handlers))))
+
+(defn update-project [project-id filters with-data & handlers]
+  (let [url (str "/api/projects/" project-id)
+        params {:id project-id
+                :filters filters
+                :with (some-> with-data name)}]
+    (PUT url
+        (json-request
+         params
+         handlers
+         :mapper-fn (partial merge (dissoc filters :facilities))))))
+
+;; Dataset related APIs
+
+(defn fetch-facility-types [dataset-id & handlers]
+  (GET "/api/facilities/types" (json-request {:dataset-id dataset-id} handlers)))
+
+
+;; Facilities related APIs
+
+(defn- process-filters [filters]
+  ;; TODO: Make the set->vector conversion generic and move it into an interceptor
+  (let [processed-filters (into {} (for [[k v] filters] [k (if (set? v) (apply vector v) v)]))]
+    (if (seq (:type filters))
+      processed-filters
+      (assoc processed-filters :type ""))))
+
+(defn fetch-facilities [filters & handlers]
+  (GET
+      "/api/facilities/"
+      (json-request (process-filters filters) handlers)))
+
+(defn fetch-isochrones-in-bbox [filters isochrone-options & handlers]
+  (POST
+      "/api/facilities/bbox-isochrones"
+      (json-request
+       (merge isochrone-options (process-filters filters))
+       handlers
+       :mapper-fn (partial merge isochrone-options))))
+

--- a/src/planwise/client/current_project/components/header.cljs
+++ b/src/planwise/client/current_project/components/header.cljs
@@ -1,4 +1,4 @@
-(ns planwise.client.projects.components.header
+(ns planwise.client.current-project.components.header
   (:require [re-frame.core :refer [subscribe dispatch]]
             [planwise.client.components.common :as common]
             [planwise.client.utils :as utils]
@@ -31,7 +31,7 @@
     [:div
      [:button.delete
       {:on-click (utils/with-confirm
-                   #(dispatch [:projects/delete-project project-id])
+                   #(dispatch [:current-project/delete-project])
                    "Are you sure you want to delete this project?")}
       (common/icon :delete "icon-small")
       "Delete project"]]]])

--- a/src/planwise/client/current_project/components/sidebar.cljs
+++ b/src/planwise/client/current_project/components/sidebar.cljs
@@ -36,13 +36,13 @@
 
 (defn- facility-filters []
   (let [facility-types (subscribe [:current-project/filter-definition :facility-type])
-        facility-ownerships (subscribe [:current-project/filter-definition :facility-ownership])
-        facility-services (subscribe [:current-project/filter-definition :facility-service])
+        ;; facility-ownerships (subscribe [:current-project/filter-definition :facility-ownership])
+        ;; facility-services (subscribe [:current-project/filter-definition :facility-service])
         filters (subscribe [:current-project/facilities :filters])
-        filter-stats (subscribe [:current-project/facilities :filter-stats])]
+        stats (subscribe [:current-project/facilities :stats])]
     (fn []
-      (let [filter-count (:count @filter-stats)
-            filter-total (:total @filter-stats)
+      (let [filter-count (:facilities-targeted @stats)
+            filter-total (:facilities-total @stats)
             toggle-cons-fn (fn [field]
                              #(dispatch [:current-project/toggle-filter :facilities field %]))]
         [:div.sidebar-filters

--- a/src/planwise/client/current_project/components/sidebar.cljs
+++ b/src/planwise/client/current_project/components/sidebar.cljs
@@ -1,11 +1,11 @@
-(ns planwise.client.projects.components.sidebar
+(ns planwise.client.current-project.components.sidebar
   (:require-macros [reagent.ratom :refer [reaction]])
   (:require [re-frame.core :refer [subscribe dispatch]]
             [re-com.core :as rc]
             [planwise.client.components.common :refer [icon]]
             [planwise.client.components.progress-bar :as progress-bar]
             [planwise.client.components.filters :as filters]
-            [planwise.client.projects.db :as db]
+            [planwise.client.current-project.db :as db]
             [planwise.client.styles :as styles]
             [planwise.client.utils :as utils]))
 
@@ -16,7 +16,7 @@
    [:div.stat-value value]])
 
 (defn- demographics-filters []
-  (let [current-project (subscribe [:projects/current-data])]
+  (let [current-project (subscribe [:current-project/current-data])]
     (fn []
       (let [population (:region-population @current-project)
             area (:region-area-km2 @current-project)
@@ -35,16 +35,16 @@
            [:a {:href "https://creativecommons.org/licenses/by/4.0/" :target "attribution"} "CC BY"]]]]))))
 
 (defn- facility-filters []
-  (let [facility-types (subscribe [:filter-definition :facility-type])
-        facility-ownerships (subscribe [:filter-definition :facility-ownership])
-        facility-services (subscribe [:filter-definition :facility-service])
-        filters (subscribe [:projects/facilities :filters])
-        filter-stats (subscribe [:projects/facilities :filter-stats])]
+  (let [facility-types (subscribe [:current-project/filter-definition :facility-type])
+        facility-ownerships (subscribe [:current-project/filter-definition :facility-ownership])
+        facility-services (subscribe [:current-project/filter-definition :facility-service])
+        filters (subscribe [:current-project/facilities :filters])
+        filter-stats (subscribe [:current-project/facilities :filter-stats])]
     (fn []
       (let [filter-count (:count @filter-stats)
             filter-total (:total @filter-stats)
             toggle-cons-fn (fn [field]
-                             #(dispatch [:projects/toggle-filter :facilities field %]))]
+                             #(dispatch [:current-project/toggle-filter :facilities field %]))]
         [:div.sidebar-filters
          [:div.filter-info
           [:p "Select the types of facility to include in your analysis. We will use those to calculate the existing coverage."]
@@ -80,7 +80,7 @@
               :toggle-fn (toggle-cons-fn :services)})]]))))
 
 (defn- transport-filters []
-  (let [transport-time (subscribe [:projects/transport-time])]
+  (let [transport-time (subscribe [:current-project/transport-time])]
     (fn []
       [:div.sidebar-filters
        [:div.filter-info
@@ -93,15 +93,13 @@
         [rc/single-dropdown
          :choices (:time db/transport-definitions)
          :label-fn :name
-         :on-change #(dispatch [:projects/set-transport-time %])
+         :on-change #(dispatch [:current-project/set-transport-time %])
          :model transport-time]
         (icon :car)]])))
 
 (defn sidebar-section [selected-tab]
-  [:aside (condp = selected-tab
-           :demographics
-           [demographics-filters]
-           :facilities
-           [facility-filters]
-           :transport
-           [transport-filters])])
+  [:aside
+   (case selected-tab
+     :demographics [demographics-filters]
+     :facilities   [facility-filters]
+     :transport    [transport-filters])])

--- a/src/planwise/client/current_project/db.cljs
+++ b/src/planwise/client/current_project/db.cljs
@@ -1,0 +1,102 @@
+(ns planwise.client.current-project.db
+  (:require [re-frame.utils :as c]
+            [planwise.client.mapping :as maps]))
+
+
+;; Default data structures
+
+(def initial-position-and-zoom {:position [-0.0236 37.9062]
+                                :zoom 7})
+
+;; Filter definitions for transport means (by car)
+(def transport-definitions
+  {:time (concat
+          [{:id (* 60 30) :name "30 minutes"}
+           {:id (* 60 45) :name "45 minutes"}
+           {:id (* 60 60) :name "1 hour"}]
+          (map
+           (fn [total-mins]
+             (let [hours (quot total-mins 60)
+                   mins (rem total-mins 60)]
+               {:id (* 60 total-mins)
+                :name (str hours (if (> mins 0) (str ":" mins)) " hours")}))
+           (range 75 181 15)))})
+
+
+;; An empty view model for the currently selected project
+(def initial-db
+  {;; Filter definitions - these are replaced by requests to the server
+   ;; {:filter-name [{:id 123 :label "One, two, three"}]}
+   :filter-definitions  {}
+
+   :facilities   {;; Filters and stats for facilities
+                  :filters    {:type      #{}
+                               :ownership #{}
+                               :services  #{}}
+                  :count      0
+                  :total      0
+                  :list       nil  ;; array
+                  :isochrones {}}  ;; threshold => level => id => geojson
+   :transport      {:time       nil}
+   :map-view       {} ;; {:keys position zoom}
+
+   :map-state      {:current :loaded ;; [:loaded :request-pending :loading :loading-displayed]
+                    :timeout nil
+                    :request nil
+                    :request-with nil}
+
+   :demand-map-key nil ;; string
+   :unsatisfied-count nil ;; number
+   :project-data   nil}) ;; {:keys id goal region-id stats filters region-population region-area-km2}
+
+
+;; Project data manipulation functions
+
+(defn- update-viewmodel-associations
+  [viewmodel {:keys [facilities]}]
+  (cond
+    facilities
+    (assoc-in viewmodel [:facilities :list] facilities)
+    :else
+    viewmodel))
+
+(defn update-viewmodel
+  [viewmodel {:keys [filters stats] :as project-data}]
+  (let [facilities-filters (:facilities filters)
+        facilities-filters (zipmap (keys facilities-filters)
+                                   (map set (vals facilities-filters)))]
+    (-> viewmodel
+        (assoc :project-data project-data)
+        (assoc :demand-map-key (:map-key project-data))
+        (assoc :unsatisfied-count (:unsatisfied-count project-data))
+        (assoc-in [:facilities :filters] facilities-filters)
+        (assoc-in [:transport] (:transport filters))
+        (assoc-in [:facilities :total] (:facilities-total stats))
+        (assoc-in [:facilities :count] (:facilities-targeted stats))
+        (update-viewmodel-associations project-data))))
+
+(defn new-viewmodel
+  [project-data]
+  (update-viewmodel initial-db project-data))
+
+(defn project-id
+  [viewmodel]
+  (get-in viewmodel [:project-data :id]))
+
+(defn dataset-id
+  [viewmodel]
+  (get-in viewmodel [:project-data :dataset-id]))
+
+; REFACTOR: project-filters is used in update-project, while facilities-criteria in fetch-* methods; unify them
+(defn project-filters
+  [viewmodel]
+  {:facilities (get-in viewmodel [:facilities :filters])
+   :transport (:transport viewmodel)})
+
+(defn facilities-criteria
+ [viewmodel]
+ (let [filters (get-in viewmodel [:facilities :filters])
+       project-dataset-id (get-in viewmodel [:project-data :dataset-id])
+       project-region-id (get-in viewmodel [:project-data :region-id])]
+   (assoc filters :dataset-id project-dataset-id
+                  :region project-region-id)))

--- a/src/planwise/client/current_project/db.cljs
+++ b/src/planwise/client/current_project/db.cljs
@@ -1,5 +1,6 @@
 (ns planwise.client.current-project.db
-  (:require [re-frame.utils :as c]
+  (:require [schema.core :as s]
+            [re-frame.utils :as c]
             [planwise.client.mapping :as maps]))
 
 
@@ -22,58 +23,57 @@
                 :name (str hours (if (> mins 0) (str ":" mins)) " hours")}))
            (range 75 181 15)))})
 
+(s/defschema ProjectFilters
+  {:facilities {:type (s/maybe [s/Int])}
+   :transport  {:time (s/maybe s/Num)}})
+
+(s/defschema ProjectStats
+  {:facilities-total    s/Num
+   :facilities-targeted s/Num})
+
+(s/defschema ProjectData
+  {:id                    s/Int
+   :goal                  s/Str
+   :dataset-id            s/Int
+   :filters               ProjectFilters
+   :owner-id              s/Int
+   :region-id             s/Int
+   :region-name           s/Str
+   :region-area-km2       s/Num
+   :region-max-population s/Num
+   :stats                 ProjectStats})
 
 ;; An empty view model for the currently selected project
 (def initial-db
   {;; Filter definitions - these are replaced by requests to the server
    ;; {:filter-name [{:id 123 :label "One, two, three"}]}
-   :filter-definitions  {}
+   :filter-definitions {}
 
-   :facilities   {;; Filters and stats for facilities
-                  :filters    {:type      #{}
-                               :ownership #{}
-                               :services  #{}}
-                  :count      0
-                  :total      0
-                  :list       nil  ;; array
-                  :isochrones {}}  ;; threshold => level => id => geojson
-   :transport      {:time       nil}
-   :map-view       {} ;; {:keys position zoom}
+   :facilities         {:list       nil           ; array
+                        :isochrones {}}           ; threshold => level => id => geojson
+   :map-view           {}                         ; {:keys position zoom}
 
-   :map-state      {:current :loaded ;; [:loaded :request-pending :loading :loading-displayed]
-                    :timeout nil
-                    :request nil
-                    :request-with nil}
+   :map-state          {:current :loaded          ; [:loaded :request-pending :loading :loading-displayed]
+                        :timeout nil
+                        :request nil
+                        :request-with nil}
 
-   :demand-map-key nil ;; string
-   :unsatisfied-count nil ;; number
-   :project-data   nil}) ;; {:keys id goal region-id stats filters region-population region-area-km2}
+   :project-data       nil})                      ; see ProjectData above
 
 
 ;; Project data manipulation functions
 
 (defn- update-viewmodel-associations
   [viewmodel {:keys [facilities]}]
-  (cond
-    facilities
+  (if (some? facilities)
     (assoc-in viewmodel [:facilities :list] facilities)
-    :else
     viewmodel))
 
 (defn update-viewmodel
-  [viewmodel {:keys [filters stats] :as project-data}]
-  (let [facilities-filters (:facilities filters)
-        facilities-filters (zipmap (keys facilities-filters)
-                                   (map set (vals facilities-filters)))]
-    (-> viewmodel
-        (assoc :project-data project-data)
-        (assoc :demand-map-key (:map-key project-data))
-        (assoc :unsatisfied-count (:unsatisfied-count project-data))
-        (assoc-in [:facilities :filters] facilities-filters)
-        (assoc-in [:transport] (:transport filters))
-        (assoc-in [:facilities :total] (:facilities-total stats))
-        (assoc-in [:facilities :count] (:facilities-targeted stats))
-        (update-viewmodel-associations project-data))))
+  [viewmodel project-data]
+  (-> viewmodel
+      (update :project-data merge (dissoc project-data :facilities))
+      (update-viewmodel-associations project-data)))
 
 (defn new-viewmodel
   [project-data]
@@ -87,16 +87,16 @@
   [viewmodel]
   (get-in viewmodel [:project-data :dataset-id]))
 
-; REFACTOR: project-filters is used in update-project, while facilities-criteria in fetch-* methods; unify them
 (defn project-filters
   [viewmodel]
-  {:facilities (get-in viewmodel [:facilities :filters])
-   :transport (:transport viewmodel)})
+  (get-in viewmodel [:project-data :filters]))
 
 (defn facilities-criteria
- [viewmodel]
- (let [filters (get-in viewmodel [:facilities :filters])
-       project-dataset-id (get-in viewmodel [:project-data :dataset-id])
-       project-region-id (get-in viewmodel [:project-data :region-id])]
-   (assoc filters :dataset-id project-dataset-id
-                  :region project-region-id)))
+  [viewmodel]
+  (let [project-data (:project-data viewmodel)
+        filters (get-in project-data [:filters :facilities])
+        project-dataset-id (:dataset-id project-data)
+        project-region-id (:region-id project-data)]
+    (assoc filters
+           :dataset-id project-dataset-id
+           :region project-region-id)))

--- a/src/planwise/client/current_project/handlers.cljs
+++ b/src/planwise/client/current_project/handlers.cljs
@@ -1,0 +1,227 @@
+(ns planwise.client.current-project.handlers
+  (:require [re-frame.core :refer [register-handler path dispatch]]
+            [re-frame.utils :as c]
+            [clojure.string :refer [split capitalize join]]
+            [accountant.core :as accountant]
+            [planwise.client.routes :as routes]
+            [planwise.client.current-project.api :as api]
+            [planwise.client.current-project.db :as db]
+            [planwise.client.mapping :as maps]
+            [planwise.client.styles :as styles]))
+
+(def in-current-project (path [:current-project]))
+
+(def request-delay 500)
+(def loading-hint-delay 2500)
+
+;; ---------------------------------------------------------------------------
+;; Facility types handlers
+
+(register-handler
+ :current-project/fetch-facility-types
+ in-current-project
+ (fn [db [_]]
+   (let [dataset-id (db/dataset-id db)]
+     (api/fetch-facility-types dataset-id :current-project/facility-types-received))
+   db))
+
+(register-handler
+ :current-project/facility-types-received
+ in-current-project
+ (fn [db [_ types]]
+   (let [types-with-colours (map (fn [type colour]
+                                   (assoc type :colour colour))
+                                 (sort-by :value types)
+                                 (cycle styles/facility-types-palette))]
+     (assoc-in db [:filter-definitions :facility-type] types-with-colours))))
+
+;; ---------------------------------------------------------------------------
+;; Loading a project
+
+(defn section->with
+  [section]
+  (case section
+    :demographics nil
+    :facilities :facilities
+    :transport :facilities-with-demand))
+
+(register-handler
+ :current-project/navigate-project
+ in-current-project
+ (fn [db [_ project-id section]]
+   (if (not= project-id (db/project-id db))
+     (dispatch [:current-project/load-project project-id (section->with section)])
+     (case section
+       (:facilities :transport) (dispatch [:current-project/load-facilities])
+       nil))
+   db))
+
+(register-handler
+ :current-project/load-project
+ in-current-project
+ (fn [db [_ project-id with-data]]
+   (api/load-project project-id with-data
+                     :current-project/project-loaded :current-project/not-found)
+   db/initial-db))
+
+(register-handler
+ :current-project/not-found
+ in-current-project
+ (fn [db [_]]
+   (accountant/navigate! (routes/home))
+   db))
+
+(register-handler
+ :current-project/project-loaded
+ in-current-project
+  (fn [db [_ project-data]]
+    (dispatch [:current-project/fetch-facility-types])
+    (dispatch [:regions/load-regions-with-geo [(:region-id project-data)]])
+    (db/new-viewmodel project-data)))
+
+(register-handler
+ :current-project/load-facilities
+ in-current-project
+ (fn [db [_ force?]]
+   (when (or force? (nil? (get-in db [:facilities :list])))
+     (api/fetch-facilities (db/facilities-criteria db) :current-project/facilities-loaded))
+   db))
+
+(register-handler
+ :current-project/facilities-loaded
+ in-current-project
+ (fn [db [_ response]]
+   (-> db
+       (assoc-in [:facilities :count] (:count response))
+       (assoc-in [:facilities :list] (:facilities response)))))
+
+(register-handler
+ :current-project/isochrones-loaded
+ in-current-project
+ (fn [db [_ {:keys [map-key unsatisfied-count facilities threshold simplify], :as response}]]
+   (let [level (maps/simplify->geojson-level simplify)
+         isochrones  (->> facilities
+                       (filter #(some? (:isochrone %)))
+                       (map (juxt :id (comp js/JSON.parse :isochrone)))
+                       (flatten)
+                       (apply hash-map))]
+     (-> db
+       (assoc :demand-map-key map-key)
+       (assoc :unsatisfied-count unsatisfied-count)
+       (update-in [:facilities :isochrones threshold level] #(merge % isochrones))))))
+
+;; ---------------------------------------------------------------------------
+;; Project filter updating
+
+(defn set-request-timeout [db]
+  (assoc-in db [:map-state :timeout]
+            (js/setTimeout #(dispatch [:current-project/trigger-map-request]) request-delay)))
+
+(defn cancel-prev-timeout [db]
+  (update-in db [:map-state :timeout] js/clearTimeout))
+
+(defn cancel-prev-request [db]
+  (some-> (get-in db [:map-state :request]) ajax.protocols/-abort)
+  (assoc-in db [:map-state :request] nil))
+
+(register-handler
+ :current-project/show-map-loading-hint
+ in-current-project
+ (fn [db _]
+   (if (= (get-in db [:map-state :current]) :loading)
+     (assoc-in db [:map-state :current] :loading-displayed)
+     db)))
+
+(register-handler
+ :current-project/trigger-map-request
+ in-current-project
+ (fn [db _]
+   (let [filters (db/project-filters db)
+         project-id (get-in db [:project-data :id])
+         request-with (get-in db [:map-state :request-with])]
+     (-> db
+         (assoc-in [:map-state :request] (api/update-project project-id filters request-with :current-project/project-updated))
+         (assoc-in [:map-state :timeout] (js/setTimeout #(dispatch [:current-project/show-map-loading-hint]) loading-hint-delay))
+         (assoc-in [:map-state :current] :loading)))))
+
+(defn initiate-project-update [db request-with]
+  (let [new-db
+        (case (get-in db [:map-state :current])
+          :loaded            (set-request-timeout db)
+          :request-pending   (-> db
+                                 cancel-prev-timeout
+                                 set-request-timeout)
+          :loading           (-> db
+                                 cancel-prev-timeout
+                                 cancel-prev-request
+                                 set-request-timeout)
+          :loading-displayed (-> db
+                                 cancel-prev-request
+                                 set-request-timeout))]
+    (-> new-db
+        (assoc-in [:map-state :current] :request-pending)
+        (assoc-in [:map-state :request-with] request-with))))
+
+(register-handler
+ :current-project/toggle-filter
+ in-current-project
+ (fn [db [_ filter-group filter-key filter-value]]
+   (let [path [filter-group :filters filter-key]
+         current-filter (get-in db path)
+         toggled-filter (if (contains? current-filter filter-value)
+                          (disj current-filter filter-value)
+                          (conj current-filter filter-value))
+         new-db (-> db
+                    (assoc-in path (set toggled-filter))
+                    (assoc-in [:facilities :isochrones] nil))
+         filters (db/project-filters new-db)
+         project-id (get-in db [:project-data :id])]
+     (initiate-project-update new-db :facilities))))
+
+(register-handler
+ :current-project/set-transport-time
+ in-current-project
+  (fn [db [_ time]]
+    (let [new-db (-> db
+                   (assoc-in [:transport :time] time)
+                   (initiate-project-update nil))]
+      new-db)))
+
+(register-handler
+ :current-project/project-updated
+ in-current-project
+ (fn [db [_ project]]
+   (let [prev-state (get-in db [:map-state :current])
+         new-db (-> db
+                    cancel-prev-timeout
+                    (assoc-in [:map-state :current] :loaded))]
+     (dispatch [:projects/invalidate-projects])
+     (db/update-viewmodel new-db project))))
+
+;; ----------------------------------------------------------------------------
+;; Project deletion
+
+(register-handler
+ :current-project/delete-project
+ in-current-project
+ (fn [db [_]]
+   (let [id (db/project-id db)]
+     (dispatch [:projects/delete-project id]))
+   (accountant/navigate! (routes/home))
+   ;; clear the current project view model
+   db/initial-db))
+
+;; ---------------------------------------------------------------------------
+;; Project map view handlers
+
+(register-handler
+ :current-project/update-position
+ in-current-project
+ (fn [db [_ new-position]]
+   (assoc-in db [:map-view :position] new-position)))
+
+(register-handler
+ :current-project/update-zoom
+ in-current-project
+ (fn [db [_ new-zoom]]
+   (assoc-in db [:map-view :zoom] new-zoom)))

--- a/src/planwise/client/current_project/subs.cljs
+++ b/src/planwise/client/current_project/subs.cljs
@@ -27,13 +27,12 @@
 (register-sub
  :current-project/facilities
  (fn [db [_ data]]
-   (let [facility-data (reaction (get-in @db [:current-project :facilities]))]
-     (reaction
-      (case data
-        :filters (:filters @facility-data)
-        :isochrones (:isochrones @facility-data)
-        :filter-stats (select-keys @facility-data [:count :total])
-        :facilities (:list @facility-data))))))
+   (case data
+     :facilities (reaction (get-in @db [:current-project :facilities :list]))
+     :isochrones (reaction (get-in @db [:current-project :facilities :isochrones]))
+     :filters (reaction (get-in @db [:current-project :project-data :filters :facilities]))
+     :stats   (reaction (-> (get-in @db [:current-project :project-data :stats])
+                            (select-keys [:facilities-targeted :facilities-total]))))))
 
 (register-sub
  :current-project/facilities-by-type
@@ -41,16 +40,16 @@
    (let [facilities (reaction (get-in @db [:current-project :facilities :list]))
          types      (subscribe [:current-project/filter-definition :facility-type])]
      (reaction
-       (->> @facilities
-         (group-by :type-id)
-         (map (fn [[type-id fs]]
-                (let [type (->> @types
-                              (filter #(= type-id (:value %)))
-                              (first))]
-                  [type fs])))
-         (sort-by (fn [[type fs]]
-                    (count fs)))
-         (reverse))))))
+      (->> @facilities
+           (group-by :type-id)
+           (map (fn [[type-id fs]]
+                  (let [type (->> @types
+                                  (filter #(= type-id (:value %)))
+                                  (first))]
+                    [type fs])))
+           (sort-by (fn [[type fs]]
+                      (count fs)))
+           (reverse))))))
 
 (register-sub
  :current-project/facilities-criteria
@@ -60,12 +59,12 @@
 (register-sub
  :current-project/transport-time
  (fn [db [_]]
-   (reaction (get-in @db [:current-project :transport :time]))))
+   (reaction (get-in @db [:current-project :project-data :filters :transport :time]))))
 
 (register-sub
  :current-project/demand-map-key
  (fn [db [_]]
-   (reaction (get-in @db [:current-project :demand-map-key]))))
+   (reaction (get-in @db [:current-project :project-data :demand-map-key]))))
 
 (register-sub
  :current-project/map-state

--- a/src/planwise/client/current_project/subs.cljs
+++ b/src/planwise/client/current_project/subs.cljs
@@ -1,0 +1,99 @@
+(ns planwise.client.current-project.subs
+  (:require-macros [reagent.ratom :refer [reaction]])
+  (:require [re-frame.core :refer [register-sub subscribe]]
+            [planwise.client.current-project.db :as db]
+            [planwise.client.mapping :as mapping]))
+
+
+;; ----------------------------------------------------------------------------
+;; Current project subscriptions
+
+(register-sub
+ :current-project/loaded?
+ (fn [db [_]]
+   (reaction (= (get-in @db [:current-project :project-data :id])
+                (js/parseInt (get-in @db [:page-params :id]))))))
+
+(register-sub
+ :current-project/current-data
+ (fn [db [_]]
+   (reaction (get-in @db [:current-project :project-data]))))
+
+(register-sub
+ :current-project/filter-definition
+ (fn [db [_ filter]]
+   (reaction (get-in @db [:current-project :filter-definitions filter]))))
+
+(register-sub
+ :current-project/facilities
+ (fn [db [_ data]]
+   (let [facility-data (reaction (get-in @db [:current-project :facilities]))]
+     (reaction
+      (case data
+        :filters (:filters @facility-data)
+        :isochrones (:isochrones @facility-data)
+        :filter-stats (select-keys @facility-data [:count :total])
+        :facilities (:list @facility-data))))))
+
+(register-sub
+ :current-project/facilities-by-type
+ (fn [db [_ data]]
+   (let [facilities (reaction (get-in @db [:current-project :facilities :list]))
+         types      (subscribe [:current-project/filter-definition :facility-type])]
+     (reaction
+       (->> @facilities
+         (group-by :type-id)
+         (map (fn [[type-id fs]]
+                (let [type (->> @types
+                              (filter #(= type-id (:value %)))
+                              (first))]
+                  [type fs])))
+         (sort-by (fn [[type fs]]
+                    (count fs)))
+         (reverse))))))
+
+(register-sub
+ :current-project/facilities-criteria
+ (fn [db [_]]
+   (reaction (db/facilities-criteria (get-in @db [:current-project])))))
+
+(register-sub
+ :current-project/transport-time
+ (fn [db [_]]
+   (reaction (get-in @db [:current-project :transport :time]))))
+
+(register-sub
+ :current-project/demand-map-key
+ (fn [db [_]]
+   (reaction (get-in @db [:current-project :demand-map-key]))))
+
+(register-sub
+ :current-project/map-state
+ (fn [db [_]]
+   (reaction (get-in @db [:current-project :map-state :current]))))
+
+(register-sub
+ :current-project/map-view
+ (fn [db [_ field]]
+   (let [map-view (reaction (get-in @db [:current-project :map-view]))
+         current-region-id (reaction (get-in @db [:current-project :project-data :region-id]))
+         current-region-max-population (reaction (get-in @db [:current-project :project-data :region-max-population]))
+         current-region (reaction (get-in @db [:regions @current-region-id]))]
+     (reaction
+       (case field
+         :position (or
+                     (:position @map-view)
+                     (mapping/bbox-center (:bbox @current-region))
+                     (:position db/initial-position-and-zoom))
+         :zoom (or
+                 (:zoom @map-view)
+                 (+ 4 (:admin-level @current-region))
+                 (:zoom db/initial-position-and-zoom))
+         :bbox (:bbox @current-region)
+         :legend-max @current-region-max-population)))))
+
+(register-sub
+ :current-project/map-geojson
+ (fn [db [_]]
+   (let [current-region-id (reaction (get-in @db [:current-project :project-data :region-id]))]
+     (reaction (get-in @db [:regions @current-region-id :geojson])))))

--- a/src/planwise/client/current_project/views.cljs
+++ b/src/planwise/client/current_project/views.cljs
@@ -75,12 +75,8 @@
         feature-fn #(aget % "isochrone")]
 
     (fn [project-id project-dataset-id project-region-id selected-tab]
-      (cond
-
-        (#{:demographics
-           :facilities
-           :transport}
-         selected-tab)
+      (case selected-tab
+        (:demographics :facilities :transport)
         [:div
          [sidebar-section selected-tab]
          (when (= @map-state :loading-displayed)
@@ -123,13 +119,13 @@
                                                       :fillOpacity 1}]))
 
                 layer-isochrones   (when (= :transport selected-tab)
-                                      [:geojson-bbox-layer { :levels mapping/geojson-levels
-                                                              :fillOpacity 1
-                                                              :weight 2
-                                                              :color styles/black
-                                                              :group {:opacity 0.2}
-                                                              :featureFn feature-fn
-                                                              :callback @callback-fn}])
+                                      [:geojson-bbox-layer {:levels mapping/geojson-levels
+                                                            :fillOpacity 1
+                                                            :weight 2
+                                                            :color styles/black
+                                                            :group {:opacity 0.2}
+                                                            :featureFn feature-fn
+                                                            :callback @callback-fn}])
 
                 map-layers (concat [mapping/bright-base-tile-layer
                                     layer-region-boundaries
@@ -139,10 +135,12 @@
 
             (into [map-widget map-props] (filterv some? map-layers)))]]
 
-
-        (= :scenarios selected-tab)
+        :scenarios
         [:div
-         [:h1 "Scenarios"]]))))
+         [:h1 "Scenarios"]]
+
+        ;; default case
+        nil))))
 
 (defn- project-view []
   (let [page-params (subscribe [:page-params])

--- a/src/planwise/client/current_project/views.cljs
+++ b/src/planwise/client/current_project/views.cljs
@@ -1,0 +1,166 @@
+(ns planwise.client.current-project.views
+  (:require-macros [reagent.ratom :refer [reaction]])
+  (:require [re-frame.core :refer [subscribe dispatch dispatch-sync]]
+            [re-com.core :as rc]
+            [re-frame.utils :as c]
+            [clojure.string :as str]
+            [leaflet.core :refer [map-widget]]
+            [planwise.client.mapping :as mapping]
+            [planwise.client.config :as config]
+            [planwise.client.styles :as styles]
+            [planwise.client.components.common :as common]
+            [planwise.client.current-project.api :as api]
+            [planwise.client.current-project.db :as db]
+            [planwise.client.current-project.components.header :refer [header-section]]
+            [planwise.client.current-project.components.sidebar :refer [sidebar-section]]))
+
+
+(defn geojson-bbox-callback [dataset-id isochrones filters threshold]
+  (fn [level bounds bbox-excluding callback]
+    (let [level (js/parseInt level)
+          bbox-excluding (map #(js/parseInt %) bbox-excluding)
+          cache-existing (keys (get-in @isochrones [threshold level]))]
+      (api/fetch-isochrones-in-bbox
+        @filters
+        {:dataset-id dataset-id,
+         :threshold threshold,
+         :bbox bounds,
+         :excluding (str/join "," cache-existing)
+         :simplify (mapping/geojson-level->simplify level)}
+        (fn [response]
+          (dispatch-sync [:current-project/isochrones-loaded response])
+          (let [isochrones-for-level (get-in @isochrones [threshold level])
+                new-isochrones (->> response
+                                  (:facilities)
+                                  (map :id)
+                                  (remove (set bbox-excluding))
+                                  (select-keys isochrones-for-level)
+                                  (mapv (fn [[id isochrone]] {:id id, :isochrone isochrone})))]
+            (callback (clj->js new-isochrones))))))))
+
+(defn marker-popup [{:keys [name type processing-status], :as marker}]
+  (str
+    "<b>" name "</b>"
+    "<br/>"
+    type
+    (when (= "no-road-network" processing-status)
+      (str
+        "<br/>" "<br/>"
+        "<i>" "This facility is too far from the closest road and it is not being evaluated for coverage." "</i>"))))
+
+(def loading-wheel
+  [:svg.circular {:viewBox "25 25 50 50"}
+   [:circle.path {:cx 50
+                  :cy 50
+                  :fill "none"
+                  :r 20
+                  :stroke-miterlimit 10
+                  :stroke-width 2}]])
+
+(defn- project-tab [project-id project-dataset-id project-region-id selected-tab]
+  (let [facilities-by-type (subscribe [:current-project/facilities-by-type])
+        map-position (subscribe [:current-project/map-view :position])
+        map-zoom (subscribe [:current-project/map-view :zoom])
+        map-bbox (subscribe [:current-project/map-view :bbox])
+        map-legend-max (subscribe [:current-project/map-view :legend-max])
+        demand-map-key (subscribe [:current-project/demand-map-key])
+        map-geojson (subscribe [:current-project/map-geojson])
+        map-state (subscribe [:current-project/map-state])
+        marker-popup-fn marker-popup
+        marker-style-fn #(when (= "no-road-network" (:processing-status %)) {:fillColor styles/invalid-facility-type})
+        isochrones (subscribe [:current-project/facilities :isochrones])
+        project-facilities-criteria (subscribe [:current-project/facilities-criteria])
+        project-transport-time (subscribe [:current-project/transport-time])
+        callback-fn (reaction (geojson-bbox-callback project-dataset-id isochrones project-facilities-criteria @project-transport-time))
+        feature-fn #(aget % "isochrone")]
+
+    (fn [project-id project-dataset-id project-region-id selected-tab]
+      (cond
+
+        (#{:demographics
+           :facilities
+           :transport}
+         selected-tab)
+        [:div
+         [sidebar-section selected-tab]
+         (when (= @map-state :loading-displayed)
+           [:div.loading-indicator
+            [:div.loading-wheel loading-wheel]
+            [:div.loading-legend "Retrieving facilities"]])
+         [:div.map-container
+          (let [map-props   {:position @map-position
+                             :zoom @map-zoom
+                             :min-zoom 5
+                             :legend-max @map-legend-max
+                             :on-position-changed
+                             #(dispatch [:current-project/update-position %])
+                             :on-zoom-changed
+                             #(dispatch [:current-project/update-zoom %])}
+
+                layer-region-boundaries  (if @map-geojson
+                                           [:geojson-layer {:data @map-geojson
+                                                            :color styles/black
+                                                            :fit-bounds true
+                                                            :fillOpacity 0
+                                                            :weight 2}])
+
+                layer-demographics (let [demand-map     (when (= :transport selected-tab) (mapping/demand-map @demand-map-key))
+                                          population-map (mapping/region-map project-region-id)]
+                                      [:wms-tile-layer {:url config/mapserver-url
+                                                        :transparent true
+                                                        :layers mapping/layer-name
+                                                        :DATAFILE (or demand-map population-map)
+                                                        :opacity 0.6}])
+
+                layers-facilities  (when (#{:facilities :transport} selected-tab)
+                                     (for [[type facilities] @facilities-by-type]
+                                       [:point-layer {:points facilities
+                                                      :popup-fn marker-popup-fn
+                                                      :style-fn marker-style-fn
+                                                      :radius 4
+                                                      :fillColor (:colour type)
+                                                      :stroke false
+                                                      :fillOpacity 1}]))
+
+                layer-isochrones   (when (= :transport selected-tab)
+                                      [:geojson-bbox-layer { :levels mapping/geojson-levels
+                                                              :fillOpacity 1
+                                                              :weight 2
+                                                              :color styles/black
+                                                              :group {:opacity 0.2}
+                                                              :featureFn feature-fn
+                                                              :callback @callback-fn}])
+
+                map-layers (concat [mapping/bright-base-tile-layer
+                                    layer-region-boundaries
+                                    layer-demographics]
+                                   layers-facilities
+                                   [layer-isochrones])]
+
+            (into [map-widget map-props] (filterv some? map-layers)))]]
+
+
+        (= :scenarios selected-tab)
+        [:div
+         [:h1 "Scenarios"]]))))
+
+(defn- project-view []
+  (let [page-params (subscribe [:page-params])
+        current-project (subscribe [:current-project/current-data])]
+    (fn []
+      (let [project-id (:id @page-params)
+            selected-tab (:section @page-params)
+            project-goal (:goal @current-project)
+            project-dataset-id (:dataset-id @current-project)
+            project-region-id (:region-id @current-project)]
+        [:article.project-view
+         [header-section project-id project-goal selected-tab]
+         [project-tab project-id project-dataset-id project-region-id selected-tab]]))))
+
+(defn project-page []
+  (let [loaded? (subscribe [:current-project/loaded?])]
+    (fn []
+      (if @loaded?
+        [project-view]
+        [:article
+         [common/loading-placeholder]]))))

--- a/src/planwise/client/datasets/db.cljs
+++ b/src/planwise/client/datasets/db.cljs
@@ -1,7 +1,7 @@
 (ns planwise.client.datasets.db
   (:require [schema.core :as s :include-macros true]
             [planwise.client.asdf :as asdf]
-            [planwise.client.utils :refer [format-percentage]]))
+            [planwise.client.utils :refer [format-percentage remove-by-id]]))
 
 (s/defschema ServerStatus
   {:status                    (s/enum :ready :done :importing :cancelling :unknown)
@@ -151,10 +151,6 @@
 (defn resmap-authorised?
   [resmap]
   (:authorised? resmap))
-
-(defn remove-by-id
-  [coll id]
-  (filter #(not= id (:id %)) coll))
 
 (defn remove-resmap-collection
   [resmap coll-id]

--- a/src/planwise/client/datasets/handlers.cljs
+++ b/src/planwise/client/datasets/handlers.cljs
@@ -3,6 +3,7 @@
             [re-frame.utils :as c]
             [clojure.string :refer [blank?]]
             [planwise.client.asdf :as asdf]
+            [planwise.client.utils :refer [remove-by-id]]
             [planwise.client.datasets.api :as api]
             [planwise.client.datasets.db :as db]))
 
@@ -161,7 +162,7 @@
    ;; optimistic update: remove the dataset from the list and invalidate resmap infomation
    ;; to make the collection available again
    (-> db
-       (update :list asdf/swap! db/remove-by-id dataset-id)
+       (update :list asdf/swap! remove-by-id dataset-id)
        (update :resourcemap asdf/invalidate!))))
 
 (register-handler

--- a/src/planwise/client/db.cljs
+++ b/src/planwise/client/db.cljs
@@ -1,6 +1,7 @@
 (ns planwise.client.db
   (:require [planwise.client.datasets.db :as datasets]
-            [planwise.client.projects.db :as projects]))
+            [planwise.client.projects.db :as projects]
+            [planwise.client.current-project.db :as current-project]))
 
 (def initial-db
   {;; Navigation (current page)
@@ -8,12 +9,11 @@
    ;; Map of navigation params (ie. :page, :id, :section, etc)
    :page-params         {}
 
-   ;; Filter definitions - these are replaced by requests to the server
-   ;; {:filter-name [{:id 123 :label "One, two, three"}]}
-   :filter-definitions  {}
-
    ;; Projects
    :projects            projects/initial-db
+
+   ;; Currently selected project
+   :current-project     current-project/initial-db
 
    ;; Regions id => {:keys [id name admin-level & [geojson preview-geojson]]}
    :regions             {}

--- a/src/planwise/client/handlers.cljs
+++ b/src/planwise/client/handlers.cljs
@@ -1,6 +1,7 @@
 (ns planwise.client.handlers
   (:require [planwise.client.db :as db]
             [planwise.client.projects.handlers :as projects]
+            [planwise.client.current-project.handlers :as current-project]
             [planwise.client.datasets.handlers]
             [planwise.client.regions.handlers :as regions]
             [re-frame.utils :as c]
@@ -19,11 +20,10 @@
 
 (defmethod on-navigate :projects [db page {id :id, section :section, :as page-params}]
   (let [id (js/parseInt id)]
-    (dispatch [:projects/navigate-project id section])
+    (dispatch [:current-project/navigate-project id section])
     db))
 
 (defmethod on-navigate :home [db _ _]
-  (dispatch [:projects/load-projects])
   db)
 
 (defmethod on-navigate :datasets [db _ _]

--- a/src/planwise/client/projects/api.cljs
+++ b/src/planwise/client/projects/api.cljs
@@ -1,21 +1,6 @@
 (ns planwise.client.projects.api
-  (:require [ajax.core :refer [GET POST PUT DELETE]]
-            [planwise.client.api :refer [json-request]]
-            [re-frame.utils :as c]))
-
-(defn- process-filters [filters]
-  ; TODO: Make the set->vector conversion generic and move it into an interceptor
-  (let [processed-filters (into {} (for [[k v] filters] [k (if (set? v) (apply vector v) v)]))]
-    (if (seq (:type filters))
-      processed-filters
-      (assoc processed-filters :type ""))))
-
-
-(defn load-project [id with-data & handlers]
-  (let [url (str "/api/projects/" id)
-        params {:id id
-                :with (some-> with-data name)}]
-    (GET url (json-request params handlers))))
+  (:require [ajax.core :refer [GET POST DELETE]]
+            [planwise.client.api :refer [json-request]]))
 
 (defn load-projects [& handlers]
   (GET
@@ -31,30 +16,3 @@
   (DELETE
     (str "/api/projects/" id)
     (json-request {:id id} handlers)))
-
-(defn fetch-facilities [filters & handlers]
-  (GET
-     "/api/facilities/"
-     (json-request (process-filters filters) handlers)))
-
-(defn fetch-isochrones-in-bbox [filters isochrone-options & handlers]
-  (POST
-    "/api/facilities/bbox-isochrones"
-    (json-request
-      (merge isochrone-options (process-filters filters))
-      handlers
-      :mapper-fn (partial merge isochrone-options))))
-
-(defn fetch-facility-types [dataset-id & handlers]
-  (GET "/api/facilities/types" (json-request {:dataset-id dataset-id} handlers)))
-
-(defn update-project [project-id filters with-data & handlers]
-  (let [url (str "/api/projects/" project-id)
-        params {:id project-id
-                :filters filters
-                :with (some-> with-data name)}]
-    (PUT url
-      (json-request
-        params
-        handlers
-        :mapper-fn (partial merge (dissoc filters :facilities))))))

--- a/src/planwise/client/projects/db.cljs
+++ b/src/planwise/client/projects/db.cljs
@@ -1,95 +1,23 @@
 (ns planwise.client.projects.db
-  (:require [re-frame.utils :as c]
-            [planwise.client.mapping :as maps]))
+  (:require [schema.core :as s]
+            [planwise.client.asdf :as asdf]))
 
 ;; Default data structures
 
-(def initial-position-and-zoom {:position [-0.0236 37.9062]
-                                :zoom 7})
+(s/defschema Project s/Any)
 
-;; Filter definitions for transport means (by car)
-(def transport-definitions
-  {:time (concat
-          [{:id (* 60 30) :name "30 minutes"}
-           {:id (* 60 45) :name "45 minutes"}
-           {:id (* 60 60) :name "1 hour"}]
-          (map
-           (fn [total-mins]
-             (let [hours (quot total-mins 60)
-                   mins (rem total-mins 60)]
-               {:id (* 60 total-mins)
-                :name (str hours (if (> mins 0) (str ":" mins)) " hours")}))
-           (range 75 181 15)))})
-
-;; An empty view model for the currently selected project
-(def empty-viewmodel
-  {:facilities   {;; Filters and stats for facilities
-                  :filters    {:type      #{}
-                               :ownership #{}
-                               :services  #{}}
-                  :count      0
-                  :total      0
-                  :list       nil  ;; array
-                  :isochrones {}}  ;; threshold => level => id => geojson
-   :transport      {:time       nil}
-   :map-view       {} ;; {:keys position zoom}
-
-   :map-state      {:current :loaded ;; [:loaded :request-pending :loading :loading-displayed]
-                    :timeout nil
-                    :request nil
-                    :request-with nil}
-
-   :demand-map-key nil ;; string
-   :unsatisfied-count nil ;; number
-   :project-data   {}}) ;; {:keys id goal region-id stats filters region-population region-area-km2}
-
+(s/defschema ProjectsViewModel
+  {:view-state    (s/enum [:list :create-dialog :creating])
+   :list          (s/maybe (asdf/Asdf [Project]))
+   :search-string s/Str})
 
 (def initial-db
-  {:view-state    :loading ; [:loading :list :create-dialog :creating :view]
-   :list          nil
-   :search-string ""
-   :current       empty-viewmodel})
+  {:view-state    :list
+   :list          (asdf/new nil)
+   :search-string ""})
 
-
-;; Project data manipulation functions
-
-(defn- update-viewmodel-associations
-  [viewmodel {:keys [facilities]}]
-  (cond
-    facilities
-    (assoc-in viewmodel [:facilities :list] facilities)
-    :else
-    viewmodel))
-
-(defn update-viewmodel
-  [viewmodel {:keys [filters stats] :as project-data}]
-  (let [facilities-filters (:facilities filters)
-        facilities-filters (zipmap (keys facilities-filters)
-                                   (map set (vals facilities-filters)))]
-    (-> viewmodel
-        (assoc :project-data project-data)
-        (assoc :demand-map-key (:map-key project-data))
-        (assoc :unsatisfied-count (:unsatisfied-count project-data))
-        (assoc-in [:facilities :filters] facilities-filters)
-        (assoc-in [:transport] (:transport filters))
-        (assoc-in [:facilities :total] (:facilities-total stats))
-        (assoc-in [:facilities :count] (:facilities-targeted stats))
-        (update-viewmodel-associations project-data))))
-
-(defn new-viewmodel
-  [project-data]
-  (update-viewmodel empty-viewmodel project-data))
-
-; REFACTOR: project-filters is used in update-project, while facilities-criteria in fetch-* methods; unify them
-(defn project-filters
-  [viewmodel]
-  {:facilities (get-in viewmodel [:facilities :filters])
-   :transport (:transport viewmodel)})
-
-(defn facilities-criteria
- [viewmodel]
- (let [filters (get-in viewmodel [:facilities :filters])
-       project-dataset-id (get-in viewmodel [:project-data :dataset-id])
-       project-region-id (get-in viewmodel [:project-data :region-id])]
-   (assoc filters :dataset-id project-dataset-id
-                  :region project-region-id)))
+(defn show-dialog?
+  [state]
+  (case state
+    (:create-dialog :creating) true
+    false))

--- a/src/planwise/client/projects/handlers.cljs
+++ b/src/planwise/client/projects/handlers.cljs
@@ -1,39 +1,13 @@
 (ns planwise.client.projects.handlers
   (:require [re-frame.core :refer [register-handler path dispatch]]
             [accountant.core :as accountant]
-            [planwise.client.routes :as routes]
+            [planwise.client.asdf :as asdf]
+            [planwise.client.utils :refer [remove-by-id]]
             [planwise.client.projects.api :as api]
-            [clojure.string :refer [split capitalize join]]
             [planwise.client.projects.db :as db]
-            [planwise.client.mapping :as maps]
-            [planwise.client.styles :as styles]
-            [re-frame.utils :as c]))
+            [planwise.client.routes :as routes]))
 
 (def in-projects (path [:projects]))
-(def in-current-project (path [:projects :current]))
-(def in-filter-definitions (path [:filter-definitions]))
-
-(def request-delay 500)
-(def loading-hint-delay 2500)
-
-;; ---------------------------------------------------------------------------
-;; Facility types handlers
-
-(register-handler
- :projects/fetch-facility-types
- (fn [db [_ dataset-id]]
-   (api/fetch-facility-types dataset-id :projects/facility-types-received)
-   db))
-
-(register-handler
- :projects/facility-types-received
- in-filter-definitions
- (fn [db [_ types]]
-   (let [types-with-colours (map (fn [type colour]
-                                   (assoc type :colour colour))
-                              (sort-by :value types)
-                              (cycle styles/facility-types-palette))]
-     (assoc db :facility-type types-with-colours))))
 
 ;; ---------------------------------------------------------------------------
 ;; Project listing
@@ -42,11 +16,14 @@
  :projects/load-projects
  in-projects
  (fn [db [_]]
-   (if (nil? (:list db))
-     (do
-       (api/load-projects :projects/projects-loaded)
-       (assoc db :view-state :loading))
-     db)))
+   (api/load-projects :projects/projects-loaded)
+   (update db :list asdf/reload!)))
+
+(register-handler
+ :projects/invalidate-projects
+ in-projects
+ (fn [db [_]]
+   (update db :list asdf/invalidate!)))
 
 (register-handler
  :projects/projects-loaded
@@ -57,9 +34,7 @@
                          (remove nil?)
                          (set))]
      (dispatch [:regions/load-regions-with-preview region-ids])
-     (assoc db
-            :view-state :list
-            :list projects))))
+     (update db :list asdf/reset! projects))))
 
 ;; Project searching
 
@@ -98,178 +73,12 @@
    (let [project-id (:id project-data)]
      (when (nil? project-id)
        (throw "Invalid project data"))
-     (dispatch [:projects/fetch-facility-types (:dataset-id project-data)])
      (dispatch [:datasets/invalidate-datasets])   ; to update project counts for the selected dataset
+     (dispatch [:current-project/project-loaded project-data])
      (accountant/navigate! (routes/project-demographics {:id project-id}))
-     (assoc db
-            :view-state :view
-            :list (cons project-data (:list db))
-            :current (db/new-viewmodel project-data)))))
-
-;; ---------------------------------------------------------------------------
-;; Loading a project
-
-(defn section->with
-  [section]
-  (case section
-    :demographics nil
-    :facilities :facilities
-    :transport :facilities-with-demand))
-
-(register-handler
- :projects/navigate-project
- in-projects
- (fn [db [_ project-id section]]
-   (if (not= project-id (get-in db [:current :project-data :id]))
-     (dispatch [:projects/load-project project-id (section->with section)])
-     (case section
-       (:facilities :transport) (dispatch [:projects/load-facilities])
-       nil))
-   db))
-
-(register-handler
- :projects/load-project
- in-projects
- (fn [db [_ project-id with-data]]
-   (api/load-project project-id with-data
-                     :projects/project-loaded :projects/not-found)
-   (assoc db :view-state :loading
-             :current db/empty-viewmodel)))
-
-(register-handler
- :projects/not-found
- in-projects
- (fn [db [_]]
-   (accountant/navigate! (routes/home))
-   db))
-
-(register-handler
- :projects/project-loaded
- in-projects
-  (fn [db [_ project-data]]
-    (dispatch [:projects/fetch-facility-types (:dataset-id project-data)])
-    (dispatch [:regions/load-regions-with-geo [(:region-id project-data)]])
-    (assoc db :view-state :view
-              :current (db/new-viewmodel project-data))))
-
-(register-handler
- :projects/load-facilities
- in-current-project
- (fn [db [_ force?]]
-   (when (or force? (nil? (get-in db [:facilities :list])))
-     (api/fetch-facilities (db/facilities-criteria db) :projects/facilities-loaded))
-   db))
-
-(register-handler
- :projects/facilities-loaded
- in-current-project
- (fn [db [_ response]]
-   (-> db
-       (assoc-in [:facilities :count] (:count response))
-       (assoc-in [:facilities :list] (:facilities response)))))
-
-(register-handler
- :projects/isochrones-loaded
- in-current-project
- (fn [db [_ {:keys [map-key unsatisfied-count facilities threshold simplify], :as response}]]
-   (let [level (maps/simplify->geojson-level simplify)
-         isochrones  (->> facilities
-                       (filter #(some? (:isochrone %)))
-                       (map (juxt :id (comp js/JSON.parse :isochrone)))
-                       (flatten)
-                       (apply hash-map))]
      (-> db
-       (assoc :demand-map-key map-key)
-       (assoc :unsatisfied-count unsatisfied-count)
-       (update-in [:facilities :isochrones threshold level] #(merge % isochrones))))))
-
-;; ---------------------------------------------------------------------------
-;; Project filter updating
-
-(defn set-request-timeout [db]
-  (assoc-in db [:map-state :timeout]
-            (js/setTimeout #(dispatch [:projects/trigger-map-request]) request-delay)))
-
-(defn cancel-prev-timeout [db]
-  (update-in db [:map-state :timeout] js/clearTimeout))
-
-(defn cancel-prev-request [db]
-  (some-> (get-in db [:map-state :request]) ajax.protocols/-abort)
-  (assoc-in db [:map-state :request] nil))
-
-(register-handler
- :projects/show-map-loading-hint
- in-current-project
- (fn [db _]
-   (if (= (get-in db [:map-state :current]) :loading)
-     (assoc-in db [:map-state :current] :loading-displayed)
-     db)))
-
-(register-handler
- :projects/trigger-map-request
- in-current-project
- (fn [db _]
-   (let [filters (db/project-filters db)
-         project-id (get-in db [:project-data :id])
-         request-with (get-in db [:map-state :request-with])]
-     (-> db
-         (assoc-in [:map-state :request] (api/update-project project-id filters request-with :projects/project-updated))
-         (assoc-in [:map-state :timeout] (js/setTimeout #(dispatch [:projects/show-map-loading-hint]) loading-hint-delay))
-         (assoc-in [:map-state :current] :loading)))))
-
-(defn initiate-project-update [db request-with]
-  (let [new-db
-        (case (get-in db [:map-state :current])
-          :loaded            (set-request-timeout db)
-          :request-pending   (-> db
-                                 cancel-prev-timeout
-                                 set-request-timeout)
-          :loading           (-> db
-                                 cancel-prev-timeout
-                                 cancel-prev-request
-                                 set-request-timeout)
-          :loading-displayed (-> db
-                                 cancel-prev-request
-                                 set-request-timeout))]
-    (-> new-db
-        (assoc-in [:map-state :current] :request-pending)
-        (assoc-in [:map-state :request-with] request-with))))
-
-(register-handler
- :projects/toggle-filter
- in-current-project
- (fn [db [_ filter-group filter-key filter-value]]
-   (let [path [filter-group :filters filter-key]
-         current-filter (get-in db path)
-         toggled-filter (if (contains? current-filter filter-value)
-                          (disj current-filter filter-value)
-                          (conj current-filter filter-value))
-         new-db (-> db
-                    (assoc-in path (set toggled-filter))
-                    (assoc-in [:facilities :isochrones] nil))
-         filters (db/project-filters new-db)
-         project-id (get-in db [:project-data :id])]
-     (initiate-project-update new-db :facilities))))
-
-(register-handler
- :projects/set-transport-time
- in-current-project
-  (fn [db [_ time]]
-    (let [new-db (-> db
-                   (assoc-in [:transport :time] time)
-                   (initiate-project-update nil))]
-      new-db)))
-
-(register-handler
- :projects/project-updated
- in-current-project
- (fn [db [_ project]]
-   (let [prev-state (get-in db [:map-state :current])
-         new-db (-> db
-                    cancel-prev-timeout
-                    (assoc-in [:map-state :current] :loaded))]
-     (api/load-projects :projects/projects-loaded)
-     (db/update-viewmodel new-db project))))
+         (assoc :view-state :list)
+         (update :list asdf/invalidate! conj project-data)))))
 
 ;; ----------------------------------------------------------------------------
 ;; Project deletion
@@ -279,28 +88,12 @@
  in-projects
  (fn [db [_ id]]
    (api/delete-project id :projects/project-deleted)
-   (accountant/navigate! (routes/home))
    ;; optimistically delete the project from our list
-   (update db :list (partial filterv #(not= (:id %) id)))))
+   (update db :list asdf/swap! remove-by-id id)))
 
 (register-handler
  :projects/project-deleted
  in-projects
  (fn [db [_ data]]
    (let [deleted-id (:deleted data)]
-     (update db :list (partial filterv #(not= (:id %) deleted-id))))))
-
-;; ---------------------------------------------------------------------------
-;; Project map view handlers
-
-(register-handler
- :projects/update-position
- in-current-project
- (fn [db [_ new-position]]
-   (assoc-in db [:map-view :position] new-position)))
-
-(register-handler
- :projects/update-zoom
- in-current-project
- (fn [db [_ new-zoom]]
-   (assoc-in db [:map-view :zoom] new-zoom)))
+     (update db :list asdf/invalidate! remove-by-id deleted-id))))

--- a/src/planwise/client/projects/views.cljs
+++ b/src/planwise/client/projects/views.cljs
@@ -1,186 +1,26 @@
 (ns planwise.client.projects.views
   (:require-macros [reagent.ratom :refer [reaction]])
-  (:require [re-frame.core :refer [subscribe dispatch dispatch-sync]]
-            [re-com.core :as rc]
-            [re-frame.utils :as c]
-            [clojure.string :as str]
-            [leaflet.core :refer [map-widget]]
-            [planwise.client.mapping :as mapping]
-            [planwise.client.config :as config]
-            [planwise.client.styles :as styles]
-            [planwise.client.projects.api :as api]
+  (:require [re-frame.core :refer [subscribe dispatch]]
+            [planwise.client.asdf :as asdf]
             [planwise.client.projects.db :as db]
             [planwise.client.components.common :as common]
-            [planwise.client.projects.components.new-project
-             :refer [new-project-dialog]]
-            [planwise.client.projects.components.listing
-             :refer [search-box no-projects-view projects-list]]
-            [planwise.client.projects.components.header
-             :refer [header-section]]
-            [planwise.client.projects.components.sidebar
-             :refer [sidebar-section]]))
-
-(defn geojson-bbox-callback [dataset-id isochrones filters threshold]
-  (fn [level bounds bbox-excluding callback]
-    (let [level (js/parseInt level)
-          bbox-excluding (map #(js/parseInt %) bbox-excluding)
-          cache-existing (keys (get-in @isochrones [threshold level]))]
-      (api/fetch-isochrones-in-bbox
-        @filters
-        {:dataset-id dataset-id,
-         :threshold threshold,
-         :bbox bounds,
-         :excluding (str/join "," cache-existing)
-         :simplify (mapping/geojson-level->simplify level)}
-        (fn [response]
-          (dispatch-sync [:projects/isochrones-loaded response])
-          (let [isochrones-for-level (get-in @isochrones [threshold level])
-                new-isochrones (->> response
-                                  (:facilities)
-                                  (map :id)
-                                  (remove (set bbox-excluding))
-                                  (select-keys isochrones-for-level)
-                                  (mapv (fn [[id isochrone]] {:id id, :isochrone isochrone})))]
-            (callback (clj->js new-isochrones))))))))
-
-(defn marker-popup [{:keys [name type processing-status], :as marker}]
-  (str
-    "<b>" name "</b>"
-    "<br/>"
-    type
-    (when (= "no-road-network" processing-status)
-      (str
-        "<br/>" "<br/>"
-        "<i>" "This facility is too far from the closest road and it is not being evaluated for coverage." "</i>"))))
+            [planwise.client.projects.components.new-project :refer [new-project-dialog]]
+            [planwise.client.projects.components.listing :refer [no-projects-view projects-list]]))
 
 (defn project-list-page []
   (let [view-state (subscribe [:projects/view-state])
         projects (subscribe [:projects/list])
         filtered-projects (subscribe [:projects/filtered-list])]
     (fn []
-      [:article.project-list
-       (cond
-         (nil? @projects) [common/loading-placeholder]
-         (empty? @projects) [no-projects-view]
-         :else [projects-list @filtered-projects])
-       (when (or (= @view-state :creating) (= @view-state :create-dialog))
-         [common/modal-dialog {:on-backdrop-click
-                               #(dispatch [:projects/cancel-new-project])}
-          [new-project-dialog]])])))
-
-(def loading-wheel
-  [:svg.circular {:viewBox "25 25 50 50"}
-   [:circle.path {:cx 50
-                  :cy 50
-                  :fill "none"
-                  :r 20
-                  :stroke-miterlimit 10
-                  :stroke-width 2}]])
-
-(defn- project-tab [project-id project-dataset-id project-region-id selected-tab]
-  (let [facilities-by-type (subscribe [:projects/facilities-by-type])
-        map-position (subscribe [:projects/map-view :position])
-        map-zoom (subscribe [:projects/map-view :zoom])
-        map-bbox (subscribe [:projects/map-view :bbox])
-        map-legend-max (subscribe [:projects/map-view :legend-max])
-        demand-map-key (subscribe [:projects/demand-map-key])
-        map-geojson (subscribe [:projects/map-geojson])
-        map-state (subscribe [:projects/map-state])
-        marker-popup-fn marker-popup
-        marker-style-fn #(when (= "no-road-network" (:processing-status %)) {:fillColor styles/invalid-facility-type})
-        isochrones (subscribe [:projects/facilities :isochrones])
-        project-facilities-criteria (subscribe [:projects/facilities-criteria])
-        project-transport-time (subscribe [:projects/transport-time])
-        callback-fn (reaction (geojson-bbox-callback project-dataset-id isochrones project-facilities-criteria @project-transport-time))
-        feature-fn #(aget % "isochrone")]
-
-    (fn [project-id project-dataset-id project-region-id selected-tab]
-      (cond
-
-        (#{:demographics
-           :facilities
-           :transport}
-         selected-tab)
-        [:div
-         [sidebar-section selected-tab]
-         (when (= @map-state :loading-displayed)
-           [:div.loading-indicator
-            [:div.loading-wheel loading-wheel]
-            [:div.loading-legend "Retrieving facilities"]])
-         [:div.map-container
-          (let [map-props   {:position @map-position
-                             :zoom @map-zoom
-                             :min-zoom 5
-                             :legend-max @map-legend-max
-                             :on-position-changed
-                             #(dispatch [:projects/update-position %])
-                             :on-zoom-changed
-                             #(dispatch [:projects/update-zoom %])}
-
-                layer-region-boundaries  (if @map-geojson
-                                           [:geojson-layer {:data @map-geojson
-                                                            :color styles/black
-                                                            :fit-bounds true
-                                                            :fillOpacity 0
-                                                            :weight 2}])
-
-                layer-demographics (let [demand-map     (when (= :transport selected-tab) (mapping/demand-map @demand-map-key))
-                                          population-map (mapping/region-map project-region-id)]
-                                      [:wms-tile-layer {:url config/mapserver-url
-                                                        :transparent true
-                                                        :layers mapping/layer-name
-                                                        :DATAFILE (or demand-map population-map)
-                                                        :opacity 0.6}])
-
-                layers-facilities  (when (#{:facilities :transport} selected-tab)
-                                     (for [[type facilities] @facilities-by-type]
-                                       [:point-layer {:points facilities
-                                                      :popup-fn marker-popup-fn
-                                                      :style-fn marker-style-fn
-                                                      :radius 4
-                                                      :fillColor (:colour type)
-                                                      :stroke false
-                                                      :fillOpacity 1}]))
-
-                layer-isochrones   (when (= :transport selected-tab)
-                                      [:geojson-bbox-layer { :levels mapping/geojson-levels
-                                                              :fillOpacity 1
-                                                              :weight 2
-                                                              :color styles/black
-                                                              :group {:opacity 0.2}
-                                                              :featureFn feature-fn
-                                                              :callback @callback-fn}])
-
-                map-layers (concat [mapping/bright-base-tile-layer
-                                    layer-region-boundaries
-                                    layer-demographics]
-                                   layers-facilities
-                                   [layer-isochrones])]
-
-            (into [map-widget map-props] (filterv some? map-layers)))]]
-
-
-        (= :scenarios selected-tab)
-        [:div
-         [:h1 "Scenarios"]]))))
-
-(defn- project-view []
-  (let [page-params (subscribe [:page-params])
-        current-project (subscribe [:projects/current-data])]
-    (fn []
-      (let [project-id (:id @page-params)
-            selected-tab (:section @page-params)
-            project-goal (:goal @current-project)
-            project-dataset-id (:dataset-id @current-project)
-            project-region-id (:region-id @current-project)]
-        [:article.project-view
-         [header-section project-id project-goal selected-tab]
-         [project-tab project-id project-dataset-id project-region-id selected-tab]]))))
-
-(defn project-page []
-  (let [view-state (subscribe [:projects/view-state])]
-    (fn []
-      (if (= @view-state :loading)
-        [:article
-         [common/loading-placeholder]]
-        [project-view]))))
+      (let [list (asdf/value @projects)]
+        (when (asdf/should-reload? @projects)
+          (dispatch [:projects/load-projects]))
+        [:article.project-list
+         (cond
+           (nil? list) [common/loading-placeholder]
+           (empty? list) [no-projects-view]
+           :else [projects-list @filtered-projects])
+         (when (db/show-dialog? @view-state)
+           [common/modal-dialog {:on-backdrop-click
+                                 #(dispatch [:projects/cancel-new-project])}
+            [new-project-dialog]])]))))

--- a/src/planwise/client/subs.cljs
+++ b/src/planwise/client/subs.cljs
@@ -2,6 +2,7 @@
   (:require-macros [reagent.ratom :refer [reaction]])
   (:require [re-frame.core :refer [register-sub]]
             [planwise.client.projects.subs]
+            [planwise.client.current-project.subs]
             [planwise.client.datasets.subs]
             [planwise.client.regions.subs]))
 
@@ -19,7 +20,3 @@
  (fn [db _]
    (reaction (:page-params @db))))
 
-(register-sub
- :filter-definition
- (fn [db [_ filter]]
-   (reaction (get-in @db [:filter-definitions filter]))))

--- a/src/planwise/client/utils.cljs
+++ b/src/planwise/client/utils.cljs
@@ -52,3 +52,7 @@
          percentage (* 100 x)
          format-string (str "%." decimals "f%%")]
      (gstring/format format-string percentage))))
+
+(defn remove-by-id
+  [coll id]
+  (remove #(= id (:id %)) coll))

--- a/src/planwise/client/views.cljs
+++ b/src/planwise/client/views.cljs
@@ -5,6 +5,7 @@
             [planwise.client.components.nav :as nav]
             [planwise.client.components.common :refer [icon]]
             [planwise.client.projects.views :as projects]
+            [planwise.client.current-project.views :as current-project]
             [planwise.client.datasets.views :as datasets]))
 
 
@@ -32,7 +33,7 @@
   [projects/project-list-page])
 
 (defmethod content-pane :projects []
-  [projects/project-page])
+  [current-project/project-page])
 
 (defmethod content-pane :datasets []
   [datasets/datasets-page])


### PR DESCRIPTION
Closes #121 

- Splits projects view model into listing and current project view model
- Separate code to handle projects list and currently active project into different namespaces
- Simplify current project view model in the client DB, de-duplicating many filters and other pieces of information; keep everything not view state related or associations inside the `:project-data` key
