### PR TITLE
Calculate unsatisfied demand on transport tab

### DIFF
--- a/cpp/calculate-demand.cpp
+++ b/cpp/calculate-demand.cpp
@@ -150,8 +150,8 @@ long calculateUnsatisfiedDemand(std::string targetFilename, std::string demoFile
     int facilityNXBlocks = (facilityXSize + xBlockSize - 1)/xBlockSize;
     int facilityNYBlocks = (facilityYSize + yBlockSize - 1)/yBlockSize;
 
-    assert(facilityXSize <= (targetXSize - (xBlockSize * blocksYOffset)));
-    assert(facilityYSize <= (targetYSize - (yBlockSize * blocksXOffset)));
+    assert(facilityXSize <= (targetXSize - (xBlockSize * blocksXOffset)));
+    assert(facilityYSize <= (targetYSize - (yBlockSize * blocksYOffset)));
 
 #ifdef DEBUG
     std::cerr << " Facility:     " << "maxY=" << facilityMaxY << " minX=" << facilityMinX << std::endl;

--- a/cpp/calculate-demand.cpp
+++ b/cpp/calculate-demand.cpp
@@ -130,7 +130,7 @@ long calculateUnsatisfiedDemand(std::string targetFilename, std::string demoFile
     double facilityYRes = facilityProjection[5];
     double demoYRes = targetProjection[5];
     assert(std::abs(facilityYRes - demoYRes) < epsilon);
-    assert(facilityMaxY <= demoMaxY);
+    assert(facilityMaxY <= (demoMaxY + epsilon));
     double blocksRow = (demoMaxY - facilityMaxY)/(128 * demoYRes);
     assert(modf(blocksRow, &intPart) < epsilon);
     int blocksRowOffset = round(blocksRow);
@@ -140,7 +140,7 @@ long calculateUnsatisfiedDemand(std::string targetFilename, std::string demoFile
     double facilityXRes = facilityProjection[1];
     double demoXRes = targetProjection[1];
     assert(std::abs(facilityXRes - demoXRes) < epsilon);
-    assert(demoMinX <= facilityMinX);
+    assert(demoMinX <= (facilityMinX + epsilon));
     double blocksCol = (facilityMinX - demoMinX)/(128 * demoXRes);
     assert(modf(blocksCol, &intPart) < epsilon);
     int blocksColOffset = round(blocksCol);

--- a/cpp/calculate-demand.cpp
+++ b/cpp/calculate-demand.cpp
@@ -271,7 +271,7 @@ int main(int argc, char *argv[]) {
     std::cerr << "Usage: " << argv[0] << " TARGET.tif POPULATION.tif FACILITYMASK1.tif CAPACITY1 ... FACILITYMASKN.tif CAPACITYN"
       << std::endl << std::endl
       << "Example:" << std::endl
-      << " " << argv[0] << "out.tif data/populations/REGIONID.tif \\" << std::endl
+      << " " << argv[0] << "out.tif data/populations/data/REGIONID.tif \\" << std::endl
       << " data/isochrones/REGIONID/POLYGONID1.tif 500 \\" << std::endl
       << " data/isochrones/REGIONID/POLYGONID2.tif 800" << std::endl << std::endl
       << "Resulting total unsatisfied demand is returned via STDOUT." << std::endl

--- a/dev/dev.clj
+++ b/dev/dev.clj
@@ -34,7 +34,7 @@
    :paths {:bin "cpp/"
            :scripts "scripts/"
            :data "data/"}
-   :maps {:facilities-capacity 2000000}
+   :maps {:facilities-capacity 1000000}
    :mailer {:mock? true}
    :figwheel
    {:css-dirs ["resources/planwise/public/css"

--- a/resources/planwise/plpgsql/functions.sql
+++ b/resources/planwise/plpgsql/functions.sql
@@ -77,8 +77,8 @@ begin
 
   miny_blocks := trunc((unaligned_target_miny-region_ymin)/srs_block_length);
   target_miny := region_ymin+miny_blocks*srs_block_length;
-  maxy_blocks := trunc((unaligned_target_maxy-region_ymax)/srs_block_length);
-  target_maxy := region_ymax+maxy_blocks*srs_block_length;
+  maxy_blocks := trunc((region_ymax-unaligned_target_maxy)/srs_block_length);
+  target_maxy := region_ymax-maxy_blocks*srs_block_length;
 
   return target_minx || '|' || unaligned_target_miny || '|' || unaligned_target_maxx || '|' || target_maxy;
 end;

--- a/resources/planwise/plpgsql/functions.sql
+++ b/resources/planwise/plpgsql/functions.sql
@@ -77,9 +77,9 @@ begin
 
   miny_blocks := trunc((unaligned_target_miny-region_ymin)/srs_block_length);
   target_miny := region_ymin+miny_blocks*srs_block_length;
-  maxy_blocks := trunc((region_ymax-unaligned_target_maxy)/srs_block_length);
+  maxy_blocks := trunc((unaligned_target_maxy-region_ymax)/srs_block_length);
   target_maxy := region_ymax+maxy_blocks*srs_block_length;
 
-  return target_minx || '|' || target_miny || '|' || target_maxx || '|' || target_maxy;
+  return target_minx || '|' || unaligned_target_miny || '|' || unaligned_target_maxx || '|' || target_maxy;
 end;
 $$ language plpgsql;

--- a/resources/planwise/sql/facilities.sql
+++ b/resources/planwise/sql/facilities.sql
@@ -111,3 +111,15 @@ WHERE fp.facility_id = :facility-id;
 UPDATE facilities_polygons
 SET population = :population
 WHERE id = :facility-polygon-id;
+
+-- :name select-polygons-in-region :?
+SELECT fp.id AS "facility-polygon-id",
+       fp.population AS "facility-population",
+       fpr.population AS "facility-region-population"
+FROM facilities_polygons_regions AS fpr
+  INNER JOIN facilities_polygons AS fp ON fpr.facility_polygon_id = fp.id
+  INNER JOIN facilities ON facilities.id = fp.facility_id
+WHERE facilities.dataset_id = :dataset-id
+  AND fpr.region_id = :region-id
+  AND fp.threshold = :threshold AND fp.method = :algorithm
+  :snip:criteria ;

--- a/resources/planwise/sql/regions.sql
+++ b/resources/planwise/sql/regions.sql
@@ -1,14 +1,25 @@
 -- :name select-regions :? :*
-SELECT id, country, name, admin_level, ST_AsGeoJSON(ST_Envelope(the_geom)) as bbox, total_population
+SELECT id, country, name, admin_level AS "admin-level", ST_AsGeoJSON(ST_Envelope(the_geom)) AS "bbox", total_population AS "total-population"
 FROM regions
 ORDER BY admin_level DESC, name DESC;
 
 -- :name select-regions-with-preview-given-ids :? :*
-SELECT id, country, name, admin_level, ST_AsGeoJSON(preview_geom) as preview_geojson, ST_AsGeoJSON(ST_Envelope(the_geom)) as bbox, total_population
+SELECT id, country, name, admin_level, ST_AsGeoJSON(preview_geom) AS "preview-geojson", ST_AsGeoJSON(ST_Envelope(the_geom)) as bbox, total_population AS "total-population"
 FROM regions
 WHERE id IN (:v*:ids);
 
 -- :name select-regions-with-geo-given-ids :? :*
-SELECT id, country, name, admin_level, ST_AsGeoJSON(preview_geom) as preview_geojson, ST_AsGeoJSON(ST_Simplify(the_geom, :simplify), 15, 3) as geojson, ST_AsGeoJSON(ST_Envelope(the_geom)) as bbox, total_population
+SELECT id, country, name, admin_level, ST_AsGeoJSON(preview_geom) AS "preview-geojson", ST_AsGeoJSON(ST_Simplify(the_geom, :simplify), 15, 3) as geojson, ST_AsGeoJSON(ST_Envelope(the_geom)) as bbox, total_population AS "total-population"
 FROM regions
 WHERE id IN (:v*:ids);
+
+-- :name select-region :? :1
+SELECT id,
+country,
+name,
+admin_level AS "admin-level",
+total_population AS "total-population",
+max_population AS "max-population",
+raster_pixel_area AS "raster-pixel-area"
+FROM regions
+WHERE id = :id;

--- a/resources/sass/_projects.scss
+++ b/resources/sass/_projects.scss
@@ -80,7 +80,7 @@ $project-sidebar-width: 300px;
 
   z-index: 10;
 
-  width: 170px;
+  width: 180px;
   height: 45px;
   padding-left: 10px;
   padding-right: 10px;

--- a/scripts/raster-isochrone
+++ b/scripts/raster-isochrone
@@ -64,7 +64,8 @@ IFS="|" read target_minx target_miny target_maxx target_maxy <<< $extent
 if [[ ! -e $TARGET ]]; then
   gdalwarp -q \
     -te $target_minx $target_miny $target_maxx $target_maxy \
-    -co "TILED=YES" -co "BLOCKXSIZE=128" -co "BLOCKYSIZE=128" \
+    -co "TILED=YES" -co "BLOCKXSIZE=128" -co "BLOCKYSIZE=128"  \
+    -co "NBITS=1" -co "COMPRESS=CCITTFAX4" \
     -cutline PG:"dbname=${POSTGRES_DB} host=${POSTGRES_HOST} user=${POSTGRES_USER} password=${POSTGRES_PASSWORD}" \
     -csql "SELECT the_geom FROM facilities_polygons WHERE id = ${FACILITY_POLYGON_ID};" \
     $REGION_FILE $TARGET

--- a/scripts/raster-isochrone
+++ b/scripts/raster-isochrone
@@ -72,7 +72,7 @@ fi;
 
 # Create facility-polygon-region population vrt to count population
 
-POPULATION_FILE=${DATA_PATH}/populations/${REGION_ID}.tif
+POPULATION_FILE=${DATA_PATH}/populations/data/${REGION_ID}.tif
 if [[ ! -e $POPULATION_FILE ]]; then
   echo "ERROR: Region population raster ${POPULATION_FILE} not found";
   exit 1;

--- a/scripts/regions-population
+++ b/scripts/regions-population
@@ -2,6 +2,10 @@
 set -euo pipefail
 export PGPASSWORD=$POSTGRES_PASSWORD;
 
+# Creates raster files data/populations/(data|maps)/REGIONID.tif with the population
+# values of each REGIONID in the regions table and those same values
+# scaled to byte for visualisation in mapserver respectively.
+
 BIN_PATH=${BIN_PATH:-cpp}
 SCRIPT_PATH=${SCRIPT_PATH:-scripts}
 DATA_PATH=${DATA_PATH:-data}
@@ -19,24 +23,29 @@ function base-raster {
     esac
 }
 
-# Creates a raster file data/populations/REGIONID.tif with the population values
-# of each REGIONID in the regions table
-
 echo "Precalculating population aggregates per region"
-REGIONS="$(psql -d $POSTGRES_DB -U $POSTGRES_USER -h $POSTGRES_HOST -t -A -c 'SELECT id,country FROM regions WHERE total_population IS NULL OR max_population IS NULL OR raster_pixel_area IS NULL;')"
-echo " Regions: ${REGIONS}"
+REGIONS_QUERY="SELECT id ,country FROM regions WHERE total_population IS NULL OR max_population IS NULL OR raster_pixel_area IS NULL;"
+if [ $# -gt 1 ]; then
+  if [ "all" == $2 ]; then
+    REGIONS_QUERY="SELECT id, country FROM regions;"
+  fi
+fi
 
-mkdir -p ${DATA_PATH}/populations
+REGIONS=$(psql -d $POSTGRES_DB -U $POSTGRES_USER -h $POSTGRES_HOST -t -A -c "$REGIONS_QUERY")
+echo " Regions to process: $(echo REGIONS | wc -l | tr -d '[[:space:]]')"
+
+mkdir -p ${DATA_PATH}/populations/data
+mkdir -p ${DATA_PATH}/populations/maps
 
 for region in $REGIONS; do
   ID=`echo $region | cut -d \| -f 1`
   COUNTRY=`echo $region | cut -d \| -f 2`
   RASTER=${DATA_PATH}/`base-raster ${COUNTRY}`
 
-  TARGET=${DATA_PATH}/populations/${ID}.tif
+  DATA_TARGET=${DATA_PATH}/populations/data/${ID}.tif
+  VIZ_TARGET=${DATA_PATH}/populations/maps/${ID}.tif
 
-  if [[ ! -e $TARGET || "`gdalinfo $TARGET | grep -e POPULATION_SUM -e POPULATION_MAX -e PIXEL_AREA_M2 | wc -l`" -ne 3 ]]; then
-    TMP_FILE=${TARGET}-unscaled
+  if [[ ! -e $DATA_TARGET || ! -e $VIZ_TARGET || "`gdalinfo $DATA_TARGET | grep -e POPULATION_SUM -e POPULATION_MAX -e PIXEL_AREA_M2 | wc -l`" -ne 3 ]]; then
 
     echo " Warping population for ${ID}"
     gdalwarp -q \
@@ -44,33 +53,34 @@ for region in $REGIONS; do
       -crop_to_cutline \
       -cutline PG:"dbname=${POSTGRES_DB} host=${POSTGRES_HOST} user=${POSTGRES_USER} password=${POSTGRES_PASSWORD}" \
       -csql "SELECT the_geom FROM regions WHERE id = ${ID};" \
-      $RASTER $TMP_FILE
+      $RASTER $DATA_TARGET
 
     echo " Aggregating population for ${ID}"
-    IFS=' ' read -a AGGREGATES <<< $(${BIN_PATH}/aggregate-population ${TMP_FILE})
+    IFS=' ' read -a AGGREGATES <<< $(${BIN_PATH}/aggregate-population ${DATA_TARGET})
     POPULATION_SUM=${AGGREGATES[0]}
     POPULATION_MAX=${AGGREGATES[1]}
 
     echo "Calculating pixel area for ${ID}"
 
-    IFS=' ' read -a RET <<< $(${SCRIPT_PATH}/raster-pixel-size ${TMP_FILE})
+    IFS=' ' read -a RET <<< $(${SCRIPT_PATH}/raster-pixel-size ${DATA_TARGET})
     PIXEL_AREA_M2=${RET[0]}
     SATURATION=${RET[1]}
 
     echo " Normalizing raster file scale for ${ID}"
-    gdal_translate -ot Byte -scale 0 $SATURATION 0 255 $TMP_FILE $TARGET
+    gdal_translate -ot Byte -scale 0 $SATURATION 0 255 $DATA_TARGET $VIZ_TARGET
 
     echo " Storing metadata for ${ID}"
-    gdal_edit.py -mo "POPULATION_SUM=$POPULATION_SUM" -mo "POPULATION_MAX=$POPULATION_MAX" -mo "PIXEL_AREA_M2=$PIXEL_AREA_M2" $TARGET
+    for target in $DATA_TARGET $VIZ_TARGET; do
+      gdal_edit.py -mo "POPULATION_SUM=$POPULATION_SUM" -mo "POPULATION_MAX=$POPULATION_MAX" -mo "PIXEL_AREA_M2=$PIXEL_AREA_M2" $target
+    done
 
-    rm $TMP_FILE
   fi;
 
-  TOTAL_POPULATION=`gdalinfo $TARGET | grep POPULATION_SUM | cut -d = -f2`
-  MAX_POPULATION=`gdalinfo $TARGET | grep POPULATION_MAX | cut -d = -f2`
-  PIXEL_AREA_M2=`gdalinfo $TARGET | grep PIXEL_AREA_M2 | cut -d = -f2`
+  TOTAL_POPULATION=`gdalinfo $DATA_TARGET | grep POPULATION_SUM | cut -d = -f2`
+  MAX_POPULATION=`gdalinfo $DATA_TARGET | grep POPULATION_MAX | cut -d = -f2`
+  PIXEL_AREA_M2=`gdalinfo $DATA_TARGET | grep PIXEL_AREA_M2 | cut -d = -f2`
 
   echo " Updating population for ${ID}"
-  psql -d $POSTGRES_DB -U $POSTGRES_USER -h $POSTGRES_HOST -t -A \
+  psql -q -d $POSTGRES_DB -U $POSTGRES_USER -h $POSTGRES_HOST -t -A \
        -c "UPDATE regions SET total_population = ${TOTAL_POPULATION}, max_population = ${MAX_POPULATION}, raster_pixel_area = ${PIXEL_AREA_M2} WHERE id = ${ID}";
 done;

--- a/scripts/saturate-demand
+++ b/scripts/saturate-demand
@@ -1,0 +1,26 @@
+#! /bin/bash
+set -euo pipefail
+export PGPASSWORD=$POSTGRES_PASSWORD;
+
+# Creates a byte-sized raster file from a float-sized demand tif, in order to
+# use it in mapserver, saturating to the specified value. Used in maps.clj.
+
+BIN_PATH=${BIN_PATH:-cpp}
+SCRIPT_PATH=${SCRIPT_PATH:-scripts}
+DATA_PATH=${DATA_PATH:-data}
+
+if [ $# -lt 2 ]; then
+  echo "Usage: $0 DEMAND_MAP_KEY SATURATION"
+	exit 1
+fi
+
+mapkey=$1
+saturation=$2
+
+DATA_RASTER=${DATA_PATH}/demands/${mapkey}.data.tif
+VIZ_RASTER=${DATA_PATH}/demands/${mapkey}.tif
+
+if [[ ! -e $VIZ_RASTER ]]; then
+  gdal_translate -q -ot Byte -scale 0 $saturation 0 255 $DATA_RASTER $VIZ_RASTER;
+  rm $DATA_RASTER || true;
+fi

--- a/src/planwise/boundary/facilities.clj
+++ b/src/planwise/boundary/facilities.clj
@@ -16,6 +16,12 @@
      also provided; for such facilities the isochrones will not be returned,
      yet their id will still be returned.")
 
+  (polygons-in-region
+   [this dataset-id isochrone-options criteria]
+   "Returns the facilities polygons in the criteria's :region, for the facilities
+    that satisfy the specified criteria. Includes fields :facility-polygon-id,
+    :facility-population, :facility-region-population.")
+
   (list-types [this dataset-id]
     "Lists all the facility types in the dataset."))
 
@@ -31,5 +37,7 @@
      (service/list-facilities service dataset-id criteria)))
   (isochrones-in-bbox [service dataset-id isochrone-options facilities-criteria]
     (service/isochrones-in-bbox service dataset-id isochrone-options facilities-criteria))
+  (polygons-in-region [service dataset-id isochrone-options facilities-criteria]
+    (service/polygons-in-region service dataset-id isochrone-options facilities-criteria))
   (list-types [service dataset-id]
     (service/list-types service dataset-id)))

--- a/src/planwise/boundary/maps.clj
+++ b/src/planwise/boundary/maps.clj
@@ -7,6 +7,9 @@
   (mapserver-url [service]
     "Retrieve the demographics tile URL template")
 
+  (default-capacity [service]
+    "Retrieves the default capacity of a facility for calculating coverage")
+
   (demand-map [service region-id polygons]
     "Returns the key for an unsatsified demand tile layer and the total unsatisfied demand,
      for the specified region and using the chosen facility polygons"))
@@ -17,5 +20,7 @@
   planwise.component.maps.MapsService
   (mapserver-url [service]
     (service/mapserver-url service))
+  (default-capacity [service]
+    (service/default-capacity service))
   (demand-map [service region-id polygons]
     (service/demand-map service region-id polygons)))

--- a/src/planwise/boundary/regions.clj
+++ b/src/planwise/boundary/regions.clj
@@ -11,7 +11,10 @@
     "Returns regions including a preview geojson of their boundaries given their ids.")
 
   (list-regions-with-geo [this ids simplify]
-    "Returns regions including a simplified geojson with their boundaries given their ids."))
+    "Returns regions including a simplified geojson with their boundaries given their ids.")
+
+  (find-region [this id]
+    "Returns region by ID, or nil if not found, without including any geometries"))
 
 ;; Reference implementation
 
@@ -22,4 +25,6 @@
   (list-regions-with-preview [service ids]
     (service/list-regions-with-preview service ids))
   (list-regions-with-geo [service ids simplify]
-    (service/list-regions-with-geo service ids simplify)))
+    (service/list-regions-with-geo service ids simplify))
+  (find-region [service id]
+    (service/find-region service id)))

--- a/src/planwise/client/config.cljs
+++ b/src/planwise/client/config.cljs
@@ -17,3 +17,6 @@
 
 (def app-version
   (aget global-config "app-version"))
+
+(def facilities-default-capacity
+  (aget global-config "facilities-default-capacity"))

--- a/src/planwise/client/current_project/api.cljs
+++ b/src/planwise/client/current_project/api.cljs
@@ -55,11 +55,6 @@
     filters
     (assoc filters :type "")))
 
-(defn fetch-facilities [filters & handlers]
-  (GET
-      "/api/facilities/"
-      (json-request (process-filters filters) handlers)))
-
 (defn fetch-isochrones-in-bbox [filters isochrone-options & handlers]
   (POST
       "/api/facilities/bbox-isochrones"

--- a/src/planwise/client/current_project/components/sidebar.cljs
+++ b/src/planwise/client/current_project/components/sidebar.cljs
@@ -8,7 +8,8 @@
             [planwise.client.current-project.db :as db]
             [planwise.client.styles :as styles]
             [planwise.client.asdf :as asdf]
-            [planwise.client.utils :as utils]))
+            [planwise.client.utils :as utils]
+            [planwise.client.config :as config]))
 
 
 (defn- demographic-stat [title value]
@@ -89,7 +90,10 @@
 
 (defn- transport-filters []
   (let [transport-time (subscribe [:current-project/transport-time])
-        read-only? (subscribe [:current-project/read-only?])]
+        read-only? (subscribe [:current-project/read-only?])
+        satisfied-demand (subscribe [:current-project/satisfied-demand])
+        current-project (subscribe [:current-project/current-data])
+        facilities-capacity config/facilities-default-capacity]
     (fn []
       [:div.sidebar-filters
        [:div.filter-info
@@ -98,7 +102,14 @@
          already has access to the services being analyzed."]
          [:p "Indicate here the acceptable one-way travel time to facilities. We will
          use that to calculate who already has access to the services that you
-         are analyzing."])]
+         are analyzing."])
+        (let [satisfied (or @satisfied-demand 0)
+              total (:region-population @current-project)]
+         [:p
+          [:div.small "With access / Total Population"]
+          [:div (str (utils/format-number satisfied) " / " (utils/format-number total))]
+          [progress-bar/progress-bar satisfied total]
+          [:div.small.facilities-stats (str "Assuming that each facility can provide coverage for a population of " (utils/format-number facilities-capacity))]])]
 
        [:fieldset
         [:legend "By car"]

--- a/src/planwise/client/current_project/db.cljs
+++ b/src/planwise/client/current_project/db.cljs
@@ -60,7 +60,7 @@
                         :isochrones {}}           ; threshold => level => id => geojson
    :map-view           {}                         ; {:keys position zoom}
 
-   :map-key            nil
+   :map-key            (asdf/new nil)
 
    :map-state          {:current :loaded          ; [:loaded :request-pending :loading :loading-displayed]
                         :timeout nil
@@ -92,7 +92,7 @@
       (update vm :shares asdf/reset! shares)
       vm)
     (update-in vm [:sharing :token] asdf/reset! share-token)
-    (assoc vm :map-key map-key)))
+    (update-in vm [:map-key] asdf/reset! map-key)))
 
 (defn update-viewmodel
   [viewmodel project-data]

--- a/src/planwise/client/current_project/db.cljs
+++ b/src/planwise/client/current_project/db.cljs
@@ -60,6 +60,8 @@
                         :isochrones {}}           ; threshold => level => id => geojson
    :map-view           {}                         ; {:keys position zoom}
 
+   :map-key            nil
+
    :map-state          {:current :loaded          ; [:loaded :request-pending :loading :loading-displayed]
                         :timeout nil
                         :request nil
@@ -81,7 +83,7 @@
 ;; Project data manipulation functions
 
 (defn- update-viewmodel-associations
-  [viewmodel {:keys [facilities shares share-token]}]
+  [viewmodel {:keys [facilities shares share-token map-key]}]
   (as-> viewmodel vm
     (if (some? facilities)
       (assoc-in vm [:facilities :list] facilities)
@@ -89,7 +91,8 @@
     (if (some? shares)
       (update vm :shares asdf/reset! shares)
       vm)
-    (update-in vm [:sharing :token] asdf/reset! share-token)))
+    (update-in vm [:sharing :token] asdf/reset! share-token)
+    (assoc vm :map-key map-key)))
 
 (defn update-viewmodel
   [viewmodel project-data]

--- a/src/planwise/client/current_project/db.cljs
+++ b/src/planwise/client/current_project/db.cljs
@@ -61,6 +61,7 @@
    :map-view           {}                         ; {:keys position zoom}
 
    :map-key            (asdf/new nil)
+   :unsatisfied-demand nil
 
    :map-state          {:current :loaded          ; [:loaded :request-pending :loading :loading-displayed]
                         :timeout nil
@@ -83,7 +84,7 @@
 ;; Project data manipulation functions
 
 (defn- update-viewmodel-associations
-  [viewmodel {:keys [facilities shares share-token map-key]}]
+  [viewmodel {:keys [facilities shares share-token map-key unsatisfied-count]}]
   (as-> viewmodel vm
     (if (some? facilities)
       (assoc-in vm [:facilities :list] facilities)
@@ -92,7 +93,8 @@
       (update vm :shares asdf/reset! shares)
       vm)
     (update-in vm [:sharing :token] asdf/reset! share-token)
-    (update-in vm [:map-key] asdf/reset! map-key)))
+    (update-in vm [:map-key] asdf/reset! map-key)
+    (assoc vm :unsatisfied-demand unsatisfied-count)))
 
 (defn update-viewmodel
   [viewmodel project-data]

--- a/src/planwise/client/current_project/handlers.cljs
+++ b/src/planwise/client/current_project/handlers.cljs
@@ -61,9 +61,7 @@
  (fn [db [_ project-id section]]
    (if (not= project-id (db/project-id db))
      (dispatch [:current-project/load-project project-id (section->with section)])
-     (case section
-       (:facilities :transport) (dispatch [:current-project/load-facilities]) ; TODO: Get project and extract required data, remove otherwise unused endpoint
-       nil))
+     (dispatch [:current-project/reload-project project-id (section->with section)]))
    db))
 
 (register-handler
@@ -73,6 +71,13 @@
    (api/load-project project-id with-data
                      :current-project/project-loaded :current-project/not-found)
    db/initial-db))
+
+(register-handler
+ :current-project/reload-project
+ in-current-project
+ (fn [db [_ project-id with-data]]
+   (api/load-project project-id with-data :current-project/project-updated)
+   db))
 
 (register-handler
  :current-project/access-project
@@ -103,20 +108,6 @@
  in-current-project
   (fn [db [_ project-data]]
     (project-loaded db project-data)))
-
-(register-handler
- :current-project/load-facilities
- in-current-project
- (fn [db [_ force?]]
-   (when (or force? (nil? (get-in db [:facilities :list])))
-     (api/fetch-facilities (db/facilities-criteria db) :current-project/facilities-loaded))
-   db))
-
-(register-handler
- :current-project/facilities-loaded
- in-current-project
- (fn [db [_ response]]
-   (assoc-in db [:facilities :list] (:facilities response))))
 
 (register-handler
  :current-project/isochrones-loaded
@@ -235,8 +226,7 @@
  :current-project/project-updated
  in-current-project
  (fn [db [_ project]]
-   (let [prev-state (get-in db [:map-state :current])
-         new-db (-> db
+   (let [new-db (-> db
                     cancel-prev-timeout
                     (assoc-in [:map-state :current] :loaded))]
      (dispatch [:projects/invalidate-projects])

--- a/src/planwise/client/current_project/handlers.cljs
+++ b/src/planwise/client/current_project/handlers.cljs
@@ -219,6 +219,7 @@
  (fn [db [_ time]]
    (let [new-db (-> db
                     (assoc-in [:project-data :filters :transport :time] time)
+                    (update :map-key asdf/reload!)
                     (initiate-project-update :demand))]
      new-db)))
 

--- a/src/planwise/client/current_project/handlers.cljs
+++ b/src/planwise/client/current_project/handlers.cljs
@@ -62,7 +62,7 @@
    (if (not= project-id (db/project-id db))
      (dispatch [:current-project/load-project project-id (section->with section)])
      (case section
-       (:facilities :transport) (dispatch [:current-project/load-facilities])
+       (:facilities :transport) (dispatch [:current-project/load-facilities]) ; TODO: Get project and extract required data, remove otherwise unused endpoint
        nil))
    db))
 
@@ -228,7 +228,7 @@
  (fn [db [_ time]]
    (let [new-db (-> db
                     (assoc-in [:project-data :filters :transport :time] time)
-                    (initiate-project-update nil))]
+                    (initiate-project-update :demand))]
      new-db)))
 
 (register-handler

--- a/src/planwise/client/current_project/handlers.cljs
+++ b/src/planwise/client/current_project/handlers.cljs
@@ -17,7 +17,7 @@
 (def in-current-project (path [:current-project]))
 
 (def request-delay 500)
-(def loading-hint-delay 2500)
+(def loading-hint-delay 1000)
 
 ;; ---------------------------------------------------------------------------
 ;; Facility types handlers

--- a/src/planwise/client/current_project/subs.cljs
+++ b/src/planwise/client/current_project/subs.cljs
@@ -103,9 +103,9 @@
    (reaction (get-in @db [:current-project :project-data :filters :transport :time]))))
 
 (register-sub
- :current-project/demand-map-key
+ :current-project/map-key
  (fn [db [_]]
-   (reaction (get-in @db [:current-project :project-data :demand-map-key]))))
+   (reaction (get-in @db [:current-project :map-key]))))
 
 (register-sub
  :current-project/map-state

--- a/src/planwise/client/current_project/subs.cljs
+++ b/src/planwise/client/current_project/subs.cljs
@@ -108,6 +108,20 @@
    (reaction (get-in @db [:current-project :map-key]))))
 
 (register-sub
+ :current-project/unsatisfied-demand
+ (fn [db [_]]
+   (reaction (get-in @db [:current-project :unsatisfied-demand]))))
+
+(register-sub
+ :current-project/satisfied-demand
+ (fn [db [_]]
+   (let [project-data (subscribe [:current-project/current-data])
+         unsatisfied-demand (subscribe [:current-project/unsatisfied-demand])]
+     (reaction
+       (when @unsatisfied-demand
+         (- (:region-population @project-data) @unsatisfied-demand))))))
+
+(register-sub
  :current-project/map-state
  (fn [db [_]]
    (reaction (get-in @db [:current-project :map-state :current]))))

--- a/src/planwise/client/current_project/views.cljs
+++ b/src/planwise/client/current_project/views.cljs
@@ -109,12 +109,17 @@
                                                             :fillOpacity 0
                                                             :weight 2}])
 
-                layer-demographics (let [demand-map     (when (= :transport selected-tab) (mapping/demand-map @map-key))
-                                         population-map (mapping/region-map project-region-id)]
+                layer-demographics (let [population-map (mapping/region-map project-region-id)
+                                         map-datafile   (if (= :transport selected-tab)
+                                                          (when (asdf/valid? @map-key)
+                                                            (if-let [key (asdf/value @map-key)]
+                                                              (mapping/demand-map key)
+                                                              population-map))
+                                                          population-map)]
                                       [:wms-tile-layer {:url config/mapserver-url
                                                         :transparent true
                                                         :layers mapping/layer-name
-                                                        :DATAFILE (or demand-map population-map)
+                                                        :DATAFILE map-datafile
                                                         :opacity 0.6}])
 
                 layers-facilities  (when (#{:facilities :transport} selected-tab)

--- a/src/planwise/client/current_project/views.cljs
+++ b/src/planwise/client/current_project/views.cljs
@@ -67,7 +67,7 @@
         map-bbox (subscribe [:current-project/map-view :bbox])
         map-pixel-max-value (subscribe [:current-project/map-view :pixel-max-value])
         map-pixel-area (subscribe [:current-project/map-view :pixel-area-m2])
-        demand-map-key (subscribe [:current-project/demand-map-key])
+        map-key (subscribe [:current-project/map-key])
         map-geojson (subscribe [:current-project/map-geojson])
         map-state (subscribe [:current-project/map-state])
         marker-popup-fn marker-popup
@@ -105,8 +105,8 @@
                                                             :fillOpacity 0
                                                             :weight 2}])
 
-                layer-demographics (let [demand-map     (when (= :transport selected-tab) (mapping/demand-map @demand-map-key))
-                                          population-map (mapping/region-map project-region-id)]
+                layer-demographics (let [demand-map     (when (= :transport selected-tab) (mapping/demand-map @map-key))
+                                         population-map (mapping/region-map project-region-id)]
                                       [:wms-tile-layer {:url config/mapserver-url
                                                         :transparent true
                                                         :layers mapping/layer-name

--- a/src/planwise/client/current_project/views.cljs
+++ b/src/planwise/client/current_project/views.cljs
@@ -116,11 +116,12 @@
                                                               (mapping/demand-map key)
                                                               population-map))
                                                           population-map)]
-                                      [:wms-tile-layer {:url config/mapserver-url
-                                                        :transparent true
-                                                        :layers mapping/layer-name
-                                                        :DATAFILE map-datafile
-                                                        :opacity 0.6}])
+                                      (when map-datafile
+                                        [:wms-tile-layer {:url config/mapserver-url
+                                                          :transparent true
+                                                          :layers mapping/layer-name
+                                                          :DATAFILE map-datafile
+                                                          :opacity 0.6}]))
 
                 layers-facilities  (when (#{:facilities :transport} selected-tab)
                                      (for [[type facilities] @facilities-by-type]

--- a/src/planwise/client/current_project/views.cljs
+++ b/src/planwise/client/current_project/views.cljs
@@ -86,7 +86,11 @@
          (when (= @map-state :loading-displayed)
            [:div.loading-indicator
             [:div.loading-wheel loading-wheel]
-            [:div.loading-legend "Retrieving facilities"]])
+            [:div.loading-legend
+             (case selected-tab
+              :demographics "Loading demographics"
+              :facilities "Retrieving facilities"
+              :transport "Calculating coverage")]])
          [:div.map-container
           (let [map-props   {:position @map-position
                              :zoom @map-zoom

--- a/src/planwise/client/mapping.cljs
+++ b/src/planwise/client/mapping.cljs
@@ -74,4 +74,4 @@
    given the id of the region"
   [region-id]
   (some->> region-id
-    (str "populations/")))
+    (str "populations/maps/")))

--- a/src/planwise/component/facilities.clj
+++ b/src/planwise/component/facilities.clj
@@ -77,6 +77,13 @@
          (assoc :dataset-id dataset-id
                 :criteria (criteria-snip criteria))))))
 
+(defn polygons-in-region
+  [service dataset-id isochrone-options criteria]
+  (select-polygons-in-region (get-db service) (assoc (isochrone-params isochrone-options)
+                                               :dataset-id dataset-id
+                                               :region-id (:region criteria)
+                                               :criteria (criteria-snip criteria))))
+
 (defn list-types [service dataset-id]
   (select-types-in-dataset (get-db service) {:dataset-id dataset-id}))
 

--- a/src/planwise/component/maps.clj
+++ b/src/planwise/component/maps.clj
@@ -16,6 +16,10 @@
   [{config :config}]
   (:mapserver-url config))
 
+(defn default-capacity
+  [{config :config}]
+  (:default-capacity config))
+
 (defn calculate-demand?
   [{config :config}]
   (boolean (:calculate-demand config)))
@@ -25,7 +29,7 @@
   (digest/sha-256
     (str/join "_" (cons region-id polygons-with-capacities))))
 
-(defn- default-capacity
+(defn default-capacity
   [{config :config}]
   (:facilities-capacity config))
 

--- a/src/planwise/component/maps.clj
+++ b/src/planwise/component/maps.clj
@@ -35,7 +35,7 @@
 
 (defn- populations-path
   [service & args]
-  (apply data-path service (cons "populations/" args)))
+  (apply data-path service (cons "populations/data/" args)))
 
 (defn- isochrones-path
   [service & args]

--- a/src/planwise/component/maps.clj
+++ b/src/planwise/component/maps.clj
@@ -16,10 +16,6 @@
   [{config :config}]
   (:mapserver-url config))
 
-(defn default-capacity
-  [{config :config}]
-  (:default-capacity config))
-
 (defn calculate-demand?
   [{config :config}]
   (boolean (:calculate-demand config)))

--- a/src/planwise/component/maps.clj
+++ b/src/planwise/component/maps.clj
@@ -57,6 +57,11 @@
     (* scale-saturation raster-pixel-area)
     1000000.0))
 
+(defn- setup-demands-folder
+  [service]
+  (let [path (demands-path service "-")]
+    (clojure.java.io/make-parents path)))
+
 (defn- create-map-raster
   [service map-key region-id]
   (let [region (regions/find-region (:regions service) region-id)
@@ -80,6 +85,7 @@
                                               #(str (capacity-for service %))))
                                         (flatten))
             map-key  (demand-map-key region-id polygons-with-capacities)
+            _ (setup-demands-folder service)
             response (apply run-external
                         (:runner service)
                         :bin

--- a/src/planwise/component/regions.clj
+++ b/src/planwise/component/regions.clj
@@ -14,12 +14,10 @@
   (get-in service [:db :spec]))
 
 (defn db->region [{json-bbox :bbox, :as record}]
-  (let [[se ne nw sw se'] (map reverse (get-in (json/read-str json-bbox) ["coordinates" 0]))]
-    (-> record
-      (assoc :bbox [sw ne])
-      (set/rename-keys {:admin_level :admin-level
-                        :preview_geojson :preview-geojson}))))
-
+  (if json-bbox
+    (let [[se ne nw sw se'] (map reverse (get-in (json/read-str json-bbox) ["coordinates" 0]))]
+      (assoc record :bbox [sw ne]))
+    record))
 
 ;; ----------------------------------------------------------------------
 ;; Service definition
@@ -46,3 +44,6 @@
 (defn list-regions-with-geo [service ids simplify]
   (map db->region
     (select-regions-with-geo-given-ids (get-db service) {:ids ids, :simplify simplify})))
+
+(defn find-region [service id]
+  (db->region (select-region (get-db service) {:id id})))

--- a/src/planwise/component/runner.clj
+++ b/src/planwise/component/runner.clj
@@ -8,9 +8,11 @@
 
 (defn- path-for
   [service kind name]
-  (if-let [folder (kind service)]
-    (apply str (kind service) name)
-    (throw (ex-info (str "Path for " kind " not found") {:kind kind}))))
+  (if kind
+    (if-let [folder (kind service)]
+      (apply str (kind service) name)
+      (throw (ex-info (str "Path for " kind " not found") {:kind kind})))
+    name))
 
 (defn run-external
   [service kind timeout name & args]

--- a/src/planwise/endpoint/home.clj
+++ b/src/planwise/endpoint/home.clj
@@ -35,6 +35,7 @@
   [{:keys [auth resmap request maps globals]}]
   (let [resmap-url (:url resmap)
         mapserver-url (maps/mapserver-url maps)
+        default-capacity (maps/default-capacity maps)
         ident (util/request-ident request)
         email (util/request-user-email request)
         token (create-jwe-token auth ident)
@@ -43,7 +44,9 @@
                 :identity email
                 :jwe-token token
                 :mapserver-url mapserver-url
-                :app-version app-version}]
+                :app-version app-version
+                :facilities-default-capacity default-capacity}]
+
     [:script (str "var _CONFIG=" (json/generate-string config) ";")]))
 
 (defn loading-page

--- a/src/planwise/system.clj
+++ b/src/planwise/system.clj
@@ -208,7 +208,8 @@
                                 :resmap-auth-endpoint]
 
           ; Components
-          :maps                [:runner]
+          :maps                [:runner
+                                :regions]
           :facilities          [:db
                                 :runner]
           :projects            [:db

--- a/test/planwise/component/regions_test.clj
+++ b/test/planwise/component/regions_test.clj
@@ -21,16 +21,16 @@
   (with-system (system)
     (let [service (:regions system)
           [kenya & rest] (regions/list-regions service)]
-    (is (= 1000 (:total_population kenya))))))
+     (is (= 1000 (:total-population kenya))))))
 
 (deftest total-population-is-retrieved-with-list-regions-with-preview
   (with-system (system)
     (let [service (:regions system)
           [kenya & rest] (regions/list-regions-with-preview service [1])]
-      (is (= 1000 (:total_population kenya))))))
+      (is (= 1000 (:total-population kenya))))))
 
 (deftest total-population-is-retrieved-with-list-regions-with-geo
   (with-system (system)
     (let [service (:regions system)
           [kenya & rest] (regions/list-regions-with-geo service [1] 0.5)]
-      (is (= 1000 (:total_population kenya))))))
+      (is (= 1000 (:total-population kenya))))))


### PR DESCRIPTION
Fixes #187

Makes use of `calculate-demand` to calculate the raster on the fly and show it on mapserver. Also displays the satisfied demand as a progress bar on the transport tab.

Requires all facilities to be re-processed, and `calculate-demand` and `raster-isochrones` env vars to be set to "true".

<img width="1186" alt="screen shot 2016-09-13 at 10 06 44 am" src="https://cloud.githubusercontent.com/assets/429604/18474707/d197f8fc-7999-11e6-92fc-4ed3f8499e0a.png">
