### PR TITLE
Try to fix isolated segments.

### DIFF
--- a/resources/planwise/plpgsql/fix-isolated.sql
+++ b/resources/planwise/plpgsql/fix-isolated.sql
@@ -1,0 +1,82 @@
+CREATE OR REPLACE FUNCTION insert_way (class_id integer, speed integer, source bigint, target bigint)
+RETURNS integer AS $$
+DECLARE
+  source_node RECORD;
+  target_node RECORD;
+  geom GEOMETRY;
+  length_m float;
+  new_gid BIGINT;
+BEGIN
+  SELECT * FROM ways_vertices_pgr WHERE id = source INTO source_node;
+  SELECT * FROM ways_vertices_pgr WHERE id = target INTO target_node;
+
+  geom := ST_MakeLine(ARRAY[source_node.the_geom, target_node.the_geom]);
+  length_m := ST_Length(geom::geography);
+
+  INSERT INTO ways
+         (class_id, length, length_m, source, target, x1, y1, x2, y2,
+          cost, one_way, maxspeed_forward, the_geom)
+         VALUES (class_id, ST_Length(geom), length_m, source, target,
+                 ST_X(source_node.the_geom), ST_Y(source_node.the_geom),
+                 ST_X(target_node.the_geom), ST_Y(target_node.the_geom),
+                 ST_Length(geom), 0, speed, geom)
+  RETURNING gid INTO new_gid;
+  UPDATE ways_vertices_pgr SET cnt = cnt + 1 WHERE id IN (source, target);
+
+  RETURN new_gid;
+END;
+$$ LANGUAGE plpgsql;
+
+
+CREATE OR REPLACE FUNCTION connect_isolated_segments (threshold float)
+RETURNS void AS $$
+DECLARE
+  segment RECORD;
+  closest_to_source RECORD;
+  closest_to_target RECORD;
+  new_way_gid BIGINT;
+  isolated INTEGER;
+  created_ways INTEGER;
+  fixed_segments INTEGER;
+  segment_fixed BOOLEAN;
+BEGIN
+  RAISE NOTICE 'Trying to fix up isolated segments';
+
+  isolated := 0;
+  created_ways := 0;
+  fixed_segments := 0;
+
+  FOR segment IN SELECT w.*, a.the_geom AS source_geom, b.the_geom AS target_geom FROM ways w, ways_vertices_pgr a, ways_vertices_pgr b WHERE w.source = a.id AND a.cnt = 1 AND w.target = b.id AND b.cnt = 1 LOOP
+    isolated := isolated + 1;
+    segment_fixed := FALSE;
+    SELECT w.id, w.the_geom
+           FROM ways_vertices_pgr w
+           WHERE id NOT IN (segment.source, segment.target)
+           ORDER by w.the_geom <-> segment.source_geom
+           LIMIT 1
+           INTO closest_to_source;
+    IF ST_Distance(segment.source_geom::geography, closest_to_source.the_geom::geography) < threshold THEN
+       new_way_gid := insert_way(segment.class_id, segment.maxspeed_forward, segment.source, closest_to_source.id);
+       created_ways := created_ways + 1;
+       segment_fixed := TRUE;
+    END IF;
+
+    SELECT w.id, w.the_geom
+           FROM ways_vertices_pgr w
+           WHERE id NOT IN (segment.source, segment.target)
+           ORDER by w.the_geom <-> segment.target_geom
+           LIMIT 1
+           INTO closest_to_target;
+    IF ST_Distance(segment.target_geom::geography, closest_to_target.the_geom::geography) < threshold THEN
+       new_way_gid := insert_way(segment.class_id, segment.maxspeed_forward, segment.target, closest_to_target.id);
+       created_ways := created_ways + 1;
+       segment_fixed := TRUE;
+    END IF;
+
+    IF segment_fixed THEN
+      fixed_segments := fixed_segments + 1;
+    END IF;
+  END LOOP;
+  RAISE NOTICE 'Fixed % segments from a total of % isolated by creating % new ways', fixed_segments, isolated, created_ways;
+END;
+$$ LANGUAGE plpgsql;

--- a/scripts/import-osm
+++ b/scripts/import-osm
@@ -42,8 +42,13 @@ fi;
 ${OSM2PGROUTING} -f /tmp/$COUNTRY.osm -c $(dirname "${BASH_SOURCE}")/mapconfig.xml -d $POSTGRES_DB -U $POSTGRES_USER -h $POSTGRES_HOST
 
 
-# First, popylate the ways_nodes table. Then make up for ways with NULL length_m (caused by
-# bad input data from OSM).
+# Apply some post-processing:
+# - Populate the ways_nodes table.
+# - Fix ways with NULL length_m (caused by bad input data from OSM).
+# - Attempt to connect isolated segments to the main network, using a 5km
+#   threshold (5km is also the currently used theshold for considering a
+#   facility too far from the road network when computing isochrones).
+# - Recompute the cost (in seconds) by applying a traffic factor.
 #
 # When applying the traffic factor we state that the time it takes to traverse a way is 50%
 # more than allowed by the max speeds.
@@ -54,6 +59,7 @@ ${OSM2PGROUTING} -f /tmp/$COUNTRY.osm -c $(dirname "${BASH_SOURCE}")/mapconfig.x
 echo "Populating ways_nodes table"
 psql -d $POSTGRES_DB -U $POSTGRES_USER -h $POSTGRES_HOST << SQL_SCRIPT
 SELECT populate_ways_nodes();
+SELECT connect_isolated_segments(5000);
 UPDATE ways SET length_m = st_length(the_geom::geography) WHERE length_m IS NULL;
 SELECT apply_traffic_factor(1.5);
 SQL_SCRIPT

--- a/scripts/import-osm
+++ b/scripts/import-osm
@@ -56,10 +56,11 @@ ${OSM2PGROUTING} -f /tmp/$COUNTRY.osm -c $(dirname "${BASH_SOURCE}")/mapconfig.x
 # If we change this value we might also need to change the bounding buffer used to filter ways
 # before calculating facility isochrones. See `bounding_radius_meters` in the `calculate_isochrones`
 # function.
-echo "Populating ways_nodes table"
+echo "Post-processing OSM information:"
 psql -d $POSTGRES_DB -U $POSTGRES_USER -h $POSTGRES_HOST << SQL_SCRIPT
 SELECT populate_ways_nodes();
-SELECT connect_isolated_segments(5000);
+SELECT pgr_analyzeGraph('ways', 0.001, 'the_geom', 'gid');
+SELECT fixpoint_connect_isolated_segments(5000);
 UPDATE ways SET length_m = st_length(the_geom::geography) WHERE length_m IS NULL;
 SELECT apply_traffic_factor(1.5);
 SQL_SCRIPT


### PR DESCRIPTION
When importing the OSM data, as a post-processing step try to connect
the isolated segments back to the main network. The threshold used for
finding a nearby node is 5km which is the same as used when considering
a facility is too far during importing.

Closes #12 