### PR TITLE
Optimisations for preprocessing for calculate demand

### DIFF
--- a/resources/planwise/plpgsql/isochrones.sql
+++ b/resources/planwise/plpgsql/isochrones.sql
@@ -177,8 +177,9 @@ begin
     -- Populate facilities_polygons_regions with the intersection between the inserted polygon and regions
     INSERT INTO facilities_polygons_regions(facility_polygon_id, region_id, area)
     SELECT fp.id, r.id, ST_Area(ST_Intersection(fp.the_geom, r.the_geom))
-    FROM regions AS r INNER JOIN facilities_polygons AS fp
-      ON ST_Intersects(fp.the_geom, r.the_geom)
+    FROM facilities AS f
+      INNER JOIN facilities_polygons AS fp ON f.id = fp.facility_id
+      INNER JOIN regions AS r ON f.the_geom @ r.the_geom AND ST_Contains(r.the_geom, f.the_geom)
     WHERE fp.id = polygon_id;
 
     from_cost      := to_cost;

--- a/scripts/raster-isochrone
+++ b/scripts/raster-isochrone
@@ -35,7 +35,7 @@ function block_size {
 }
 
 if [ $# -lt 2 ]; then
-  echo "Usage: $0 REGION_ID FACILITY_POLYGON_ID"
+  echo "Usage: $0 REGION_ID FACILITY_POLYGON_ID [SCALE]"
 	exit 1
 fi
 
@@ -43,6 +43,11 @@ DATA_PATH=${DATA_PATH:-data}
 BIN_PATH=${BIN_PATH:-cpp}
 REGION_ID=$1
 FACILITY_POLYGON_ID=$2
+
+SCALE=1
+if [ $# -ge 3 ]; then
+  SCALE=$3
+fi
 
 # Create facility-polygon-region mask tif
 
@@ -83,16 +88,27 @@ fi;
 
 VRT_TARGET=${DATA_PATH}/isochrones/${REGION_ID}/${FACILITY_POLYGON_ID}.vrt
 
+scaled_resolution=$resolution
+if [[ $SCALE -ne 1 ]]; then
+  scaled_resolution=$(python -c "print ${resolution} * ${SCALE}")
+fi
+
 gdalwarp -q \
-  -co "TILED=YES" -co "BLOCKXSIZE=128" -co "BLOCKYSIZE=128" \
+  -overwrite \
   -cutline PG:"dbname=${POSTGRES_DB} host=${POSTGRES_HOST} user=${POSTGRES_USER} password=${POSTGRES_PASSWORD}" \
   -csql "SELECT the_geom FROM facilities_polygons WHERE id = ${FACILITY_POLYGON_ID};" \
+  -dstnodata 0 \
   -crop_to_cutline \
   -of VRT \
+  -tap \
+  -tr $scaled_resolution -$scaled_resolution \
   $POPULATION_FILE $VRT_TARGET
 
-
 IFS=' ' read -a AGGREGATES <<< $(${BIN_PATH}/aggregate-population ${VRT_TARGET})
-echo ${AGGREGATES[0]}
+if [[ $SCALE -eq 1 ]]; then
+  echo ${AGGREGATES[0]}
+else
+  echo $(python -c "print ${AGGREGATES[0]} * ${SCALE} * ${SCALE}")
+fi
 
 rm ${VRT_TARGET}

--- a/scripts/raster-isochrone
+++ b/scripts/raster-isochrone
@@ -64,6 +64,8 @@ IFS="|" read target_minx target_miny target_maxx target_maxy <<< $extent
 if [[ ! -e $TARGET ]]; then
   gdalwarp -q \
     -te $target_minx $target_miny $target_maxx $target_maxy \
+    -tap \
+    -tr $resolution -$resolution \
     -co "TILED=YES" -co "BLOCKXSIZE=128" -co "BLOCKYSIZE=128"  \
     -co "NBITS=1" -co "COMPRESS=CCITTFAX4" \
     -cutline PG:"dbname=${POSTGRES_DB} host=${POSTGRES_HOST} user=${POSTGRES_USER} password=${POSTGRES_PASSWORD}" \

--- a/scripts/raster-regions
+++ b/scripts/raster-regions
@@ -3,7 +3,11 @@ set -euo pipefail
 export PGPASSWORD=$POSTGRES_PASSWORD;
 
 # Creates a byte-sized raster file data/regions/REGIONID.tif,
-# with a mask of each region, ie a value of 255 for the region
+# with a mask of each region, ie a value of 255 for the region.
+#
+# These masks will then be used to create masks for the facility
+# polygon regions, in raster-isochrone, that are used to calculate
+# demand.
 
 DATA_PATH=${DATA_PATH:-data}
 
@@ -18,7 +22,9 @@ for id in $REGION_IDS; do
     gdal_rasterize -q -co "TILED=YES" -co "BLOCKXSIZE=128" -co "BLOCKYSIZE=128" \
       -ot byte -a_nodata 0 -burn 255 \
       -sql "SELECT the_geom FROM regions WHERE id = ${id};" \
+      -co "NBITS=1" -co "COMPRESS=CCITTFAX4" \
       -tr 0.0008333 0.0008333 \
+      -tap \
       PG:"dbname=${POSTGRES_DB} host=${POSTGRES_HOST} user=${POSTGRES_USER} password=${POSTGRES_PASSWORD}" $TARGET
   fi;
 done;

--- a/scripts/regions-population
+++ b/scripts/regions-population
@@ -23,6 +23,11 @@ function base-raster {
     esac
 }
 
+function target_resolution {
+    raster_name=$1
+    gdalinfo $raster_name | grep "Pixel Size" | sed -E 's/.*\(([^)]*).*/\1/g' | tr ',' ' '
+}
+
 echo "Precalculating population aggregates per region"
 REGIONS_QUERY="SELECT id ,country FROM regions WHERE total_population IS NULL OR max_population IS NULL OR raster_pixel_area IS NULL;"
 if [ $# -gt 1 ]; then
@@ -47,8 +52,11 @@ for region in $REGIONS; do
 
   if [[ ! -e $DATA_TARGET || ! -e $VIZ_TARGET || "`gdalinfo $DATA_TARGET | grep -e POPULATION_SUM -e POPULATION_MAX -e PIXEL_AREA_M2 | wc -l`" -ne 3 ]]; then
 
+    resolution=$(target_resolution $RASTER)
     echo " Warping population for ${ID}"
     gdalwarp -q \
+      -tap \
+      -tr $resolution \
       -co "TILED=YES" -co "BLOCKXSIZE=128" -co "BLOCKYSIZE=128" \
       -crop_to_cutline \
       -cutline PG:"dbname=${POSTGRES_DB} host=${POSTGRES_HOST} user=${POSTGRES_USER} password=${POSTGRES_PASSWORD}" \

--- a/src/planwise/boundary/maps.clj
+++ b/src/planwise/boundary/maps.clj
@@ -10,6 +10,9 @@
   (default-capacity [service]
     "Retrieves the default capacity of a facility for calculating coverage")
 
+  (calculate-demand? [service]
+    "Feature toggle flag for unsatisfied emand calculation")
+
   (demand-map [service region-id polygons]
     "Returns the key for an unsatsified demand tile layer and the total unsatisfied demand,
      for the specified region and using the chosen facility polygons"))
@@ -22,5 +25,7 @@
     (service/mapserver-url service))
   (default-capacity [service]
     (service/default-capacity service))
+  (calculate-demand? [service]
+    (service/calculate-demand? service))
   (demand-map [service region-id polygons]
     (service/demand-map service region-id polygons)))

--- a/src/planwise/client/config.cljs
+++ b/src/planwise/client/config.cljs
@@ -20,3 +20,6 @@
 
 (def facilities-default-capacity
   (aget global-config "facilities-default-capacity"))
+
+(def calculate-demand
+  (aget global-config "calculate-demand"))

--- a/src/planwise/client/current_project/components/sidebar.cljs
+++ b/src/planwise/client/current_project/components/sidebar.cljs
@@ -103,13 +103,14 @@
          [:p "Indicate here the acceptable one-way travel time to facilities. We will
          use that to calculate who already has access to the services that you
          are analyzing."])
-        (let [satisfied (or @satisfied-demand 0)
-              total (:region-population @current-project)]
-         [:p
-          [:div.small "With access / Total Population"]
-          [:div (str (utils/format-number satisfied) " / " (utils/format-number total))]
-          [progress-bar/progress-bar satisfied total]
-          [:div.small.facilities-stats (str "Assuming that each facility can provide coverage for a population of " (utils/format-number facilities-capacity))]])]
+        (when config/calculate-demand
+         (let [satisfied (or @satisfied-demand 0)
+               total (:region-population @current-project)]
+          [:p
+           [:div.small "With access / Total Population"]
+           [:div (str (utils/format-number satisfied) " / " (utils/format-number total))]
+           [progress-bar/progress-bar satisfied total]
+           [:div.small.facilities-stats (str "Assuming that each facility can provide coverage for a population of " (utils/format-number facilities-capacity))]]))]
 
        [:fieldset
         [:legend "By car"]

--- a/src/planwise/component/facilities.clj
+++ b/src/planwise/component/facilities.clj
@@ -101,10 +101,11 @@
         (vec))))
 
 (defn raster-isochrones! [service facility-id]
-  (let [facilities-polygons-regions (select-facilities-polygons-regions-for-facility (get-db service) {:facility-id facility-id})]
+  (let [scale-resolution 8
+        facilities-polygons-regions (select-facilities-polygons-regions-for-facility (get-db service) {:facility-id facility-id})]
     (doseq [{:keys [facility-polygon-id region-id] :as fpr} facilities-polygons-regions]
       (try
-        (let [population (-> (run-external (:runner service) :scripts 60000 "raster-isochrone" (str region-id) (str facility-polygon-id))
+        (let [population (-> (run-external (:runner service) :scripts 60000 "raster-isochrone" (str region-id) (str facility-polygon-id) (str scale-resolution))
                              (trim-to-int))]
           (set-facility-polygon-region-population!
             (get-db service)

--- a/src/planwise/endpoint/home.clj
+++ b/src/planwise/endpoint/home.clj
@@ -36,6 +36,7 @@
   (let [resmap-url (:url resmap)
         mapserver-url (maps/mapserver-url maps)
         default-capacity (maps/default-capacity maps)
+        calculate-demand (maps/calculate-demand? maps)
         ident (util/request-ident request)
         email (util/request-user-email request)
         token (create-jwe-token auth ident)
@@ -45,7 +46,8 @@
                 :jwe-token token
                 :mapserver-url mapserver-url
                 :app-version app-version
-                :facilities-default-capacity default-capacity}]
+                :facilities-default-capacity default-capacity
+                :calculate-demand calculate-demand}]
 
     [:script (str "var _CONFIG=" (json/generate-string config) ";")]))
 


### PR DESCRIPTION
- Compress region mask rasters to use 1-bit representation (yields almost no performance penalisation)
- Ensure all generated rasters honour the original `0.0008333` resolution
- Reduce the resolution of the virtual raster created to count the population of an isochrone-region to speed up, at the cost of a small error in the calculation
- Only generate facility-polygon-region entries for regions that contain the facility, instead for all regions that overlap with the facility's polygons
