### PR TITLE
Handle polygons without population in calculate demand

### DIFF
--- a/src/planwise/component/maps.clj
+++ b/src/planwise/component/maps.clj
@@ -49,7 +49,7 @@
 (defn- capacity-for
   [service {:keys [population population-in-region]}]
   (let [capacity (default-capacity service)
-        factor   (if population-in-region (/ population-in-region population) 1)]
+        factor   (/ population-in-region population)]
     (int (* factor capacity))))
 
 (defn- region-saturation
@@ -73,6 +73,9 @@
   [service region-id facilities]
   (->> facilities
     (filter :polygon-id)
+    (filter :population)
+    (filter (comp pos? :population))
+    (filter :population-in-region)
     (map (juxt
           #(isochrones-path service region-id "/" (:polygon-id %) ".tif")
           #(str (capacity-for service %))))


### PR DESCRIPTION
If there was an error during the import process, the population
for a polygon or a polygon-region might be null. If so, simply
skip those in the calculate demand computation instead of failing
with a null reference exception.