### PR TITLE
Update dataset

### DIFF
--- a/resources/sass/_datasets.scss
+++ b/resources/sass/_datasets.scss
@@ -113,11 +113,12 @@ article.datasets {
       }
     }
 
-    .delete {
+    .delete, .secondary {
       visibility: hidden;
     }
 
-    &:hover .delete {
+    &:hover .delete,
+    &:hover .secondary {
       visibility: visible;
     }
   }

--- a/src/planwise/client/datasets/api.cljs
+++ b/src/planwise/client/datasets/api.cljs
@@ -43,6 +43,11 @@
                     handlers
                     :mapper-fn map-dataset)))
 
+(defn update-dataset!
+  [id & handlers]
+  (POST (str "/api/datasets/" id "/update")
+    (json-request {} handlers :mapper-fn map-dataset)))
+
 (defn cancel-import!
   [dataset-id & handlers]
   (POST "/api/datasets/cancel"

--- a/src/planwise/client/datasets/components/listing.cljs
+++ b/src/planwise/client/datasets/components/listing.cljs
@@ -53,6 +53,7 @@
         :start "Waiting to start"
         :importing-types "Importing facility types"
         (:request-sites :importing-sites) (str "Importing sites from Resourcemap" progress)
+        (:delete-old-facilities :deleting-old-facilities :delete-old-types :deleting-old-types) "Deleting any stale data"
         (:processing-facilities) (str "Pre-processing facilities" progress)
         (:update-projects :updating-projects) "Updating projects"
         "Importing..."))

--- a/src/planwise/client/datasets/components/listing.cljs
+++ b/src/planwise/client/datasets/components/listing.cljs
@@ -42,7 +42,7 @@
 
 (defn- server-status->string
   [server-status]
-  (case (:status server-status)
+  (case (keyword (:status server-status))
     (nil :ready :done)
     "Ready to use"
 
@@ -70,6 +70,8 @@
               :cancelled "Import cancelled"
               :import-types-failed "Import failed, error while importing facility types"
               :import-sites-failed "Import failed, error while importing sites from ResourceMap"
+              :delete-old-facilities-failed "Import failed, error while deleting facilities for removed sites"
+              :delete-old-types-failed "Import failed, error while deleting stale facility types"
               :update-projects-failed "Import failed, error while updating related projects"
               :unexpected-event "Import failed"
               nil)]
@@ -124,26 +126,30 @@
                                         [no-road-network "facility is" "facilities are" "too far from the closest road"]]]
                              (for [[[count singular plural description] index] (zipmap warns (range)) :when (pos? count)]
                                [:li {:key index} (string/join " " [(utils/pluralize count singular plural) description])]))]]]
+
          (when importing?
            [progress-bar/progress-bar (db/import-progress server-status)])
 
-         (cond
-           importing?
-           [:div.bottom-right
+         [:div.bottom-right
+           (if importing?
             [:button.danger
              {:type :button
               :on-click #(dispatch [:datasets/cancel-import! id])
               :disabled cancelling?}
-             (if cancelling? "Cancelling..." "Cancel")]]
+             (if cancelling? "Cancelling..." "Cancel")]
+            [:div
+             [:button.secondary
+              {:on-click #(dispatch [:datasets/update-dataset id])}
+              (common/icon :refresh "icon-small")
+              "Update"]
+             (when (zero? project-count)
+              [:button.delete
+               {:on-click (utils/with-confirm
+                            #(dispatch [:datasets/delete-dataset id])
+                            "Are you sure you want to delete this dataset?")}
+               (common/icon :delete "icon-small")
+               "Delete"])])]]))))
 
-           (zero? project-count)
-           [:div.bottom-right
-            [:button.delete
-             {:on-click (utils/with-confirm
-                          #(dispatch [:datasets/delete-dataset id])
-                          "Are you sure you want to delete this dataset?")}
-             (common/icon :delete "icon-small")
-             "Delete"]])]))))
 
 (defn datasets-list
   [datasets]

--- a/src/planwise/client/datasets/handlers.cljs
+++ b/src/planwise/client/datasets/handlers.cljs
@@ -142,7 +142,7 @@
    (assoc db :state :list)))
 
 ;; ----------------------------------------------------------------------------
-;; Dataset deletion
+;; Dataset deletion and update
 
 (register-handler
  :datasets/delete-dataset
@@ -161,3 +161,16 @@
  (fn [db [_ data]]
    (dispatch [:datasets/invalidate-datasets])
    db))
+
+(register-handler
+ :datasets/update-dataset
+ in-datasets
+ (fn [db [_ dataset-id]]
+   (api/update-dataset! dataset-id :datasets/dataset-updated)
+   db))
+
+(register-handler
+ :datasets/dataset-updated
+ in-datasets
+ (fn [db [_ dataset]]
+   (update db :list asdf/swap! utils/replace-by-id dataset)))

--- a/src/planwise/client/utils.cljs
+++ b/src/planwise/client/utils.cljs
@@ -5,6 +5,7 @@
             [re-frame.core :refer [subscribe dispatch]]
             [goog.string :as gstring]
             [clojure.string :as cstring]
+            [re-frame.utils :as c]
             [goog.string.format]))
 
 ;; Debounce functions
@@ -88,6 +89,23 @@
 (defn remove-by-id
   [coll id]
   (remove #(= id (:id %)) coll))
+
+(defn replace-by-id
+  [coll replacement]
+  (let [id (:id replacement)
+        index (->> coll
+                (vec)
+                (keep-indexed #(when (= id (:id %2)) %1))
+                (first))]
+    (assoc (vec coll) index replacement)))
+
+(defn update-by-id
+  [coll id update-fn & args]
+  (let [index (->> coll
+                (vec)
+                (keep-indexed #(when (= id (:id %2)) %1))
+                (first))]
+    (apply update (vec coll) index update-fn args)))
 
 (defn remove-by
   [coll field value]

--- a/src/planwise/client/utils.cljs
+++ b/src/planwise/client/utils.cljs
@@ -90,22 +90,17 @@
   [coll id]
   (remove #(= id (:id %)) coll))
 
-(defn replace-by-id
-  [coll replacement]
-  (let [id (:id replacement)
-        index (->> coll
-                (vec)
-                (keep-indexed #(when (= id (:id %2)) %1))
-                (first))]
-    (assoc (vec coll) index replacement)))
-
 (defn update-by-id
   [coll id update-fn & args]
-  (let [index (->> coll
-                (vec)
-                (keep-indexed #(when (= id (:id %2)) %1))
-                (first))]
-    (apply update (vec coll) index update-fn args)))
+  (map (fn [item]
+         (if (= id (:id item))
+           (apply update-fn item args)
+           item))
+       coll))
+
+(defn replace-by-id
+  [coll replacement]
+  (update-by-id coll (:id replacement) (constantly replacement)))
 
 (defn remove-by
   [coll field value]

--- a/src/planwise/component/facilities.clj
+++ b/src/planwise/component/facilities.clj
@@ -39,17 +39,50 @@
 ;; ----------------------------------------------------------------------
 ;; Service functions
 
-(defn insert-facilities! [service dataset-id facilities]
+(defn insert-facilities!
+  "Upserts the facilities, identifying them by dataset-id and site-id,
+   returning a hash of state into list of ids, where state is one of
+   :existing, :updated, :moved or :new."
+  [service dataset-id facilities]
   (jdbc/with-db-transaction [tx (get-db service)]
-    (delete-facilities-in-dataset-by-site-id! tx {:dataset-id dataset-id, :site-ids (map :site-id facilities)})
-    (reduce (fn [ids facility]
-              (let [result (insert-facility! tx (assoc facility :dataset-id dataset-id))]
-                (conj ids (:id result))))
-            []
-            facilities)))
+    (let [updateable-keys [:name :type-id :lat :lon]
+          site-ids (map :site-id facilities)
+          existing-facilities (when (seq site-ids)
+                                (facilities-in-dataset-by-criteria tx
+                                  {:dataset-id dataset-id
+                                   :criteria (criteria-snip {:site-ids site-ids})}))]
+      (->> facilities
+        (map  (fn [facility]
+                (if-let [{id :id, :as existing} (some-> (filter #(= (:site-id %) (:site-id facility))
+                                                         existing-facilities)
+                                                  (first)
+                                                  (update :lat float)
+                                                  (update :lon float))]
+                  ; Check if we need to update any attribute
+                  (if (= (select-keys existing updateable-keys)
+                         (select-keys facility updateable-keys))
+                    [:existing id]
+                    ; Check if the position changed; if so, clear the processing status
+                    (if (= (select-keys existing [:lat :lon])
+                           (select-keys facility [:lat :lon]))
+                      (do
+                        (update-facility* tx (merge {:id id}
+                                                    (select-keys facility [:name :type-id])))
+                        [:updated id])
+                      (do
+                        (update-facility* tx (merge {:id id, :processing-status nil}
+                                                    (select-keys facility updateable-keys)))
+                        [:moved id])))
+                  ; Insert the new facility otherwise
+                  (let [result (insert-facility! tx (assoc facility :dataset-id dataset-id))]
+                    [:new (:id result)]))))
+        (group-by first)
+        (map (fn [[state values]] [state (map second values)]))
+        (into {})))))
 
-(defn destroy-facilities! [service dataset-id]
-  (delete-facilities-in-dataset! (get-db service) {:dataset-id dataset-id}))
+(defn destroy-facilities! [service dataset-id & [{except-ids :except-ids}]]
+  (delete-facilities-in-dataset! (get-db service) {:dataset-id dataset-id
+                                                   :except-ids except-ids}))
 
 (defn list-facilities
   ([service dataset-id]
@@ -90,17 +123,20 @@
   (select-types-in-dataset (get-db service) {:dataset-id dataset-id}))
 
 (defn destroy-types!
-  [service dataset-id]
-  (delete-types-in-dataset! (get-db service) {:dataset-id dataset-id}))
+  [service dataset-id & [{except-ids :except-ids}]]
+  (delete-types-in-dataset! (get-db service) {:dataset-id dataset-id
+                                              :except-ids except-ids}))
 
 (defn insert-types!
   [service dataset-id types]
   (jdbc/with-db-transaction [tx (get-db service)]
-    (-> (map (fn [type]
-               (let [type-id (insert-type! tx (assoc type :dataset-id dataset-id))]
-                 (merge type type-id)))
-             types)
-        (vec))))
+    (let [current-types (select-types-in-dataset tx {:dataset-id dataset-id})]
+      (->> types
+        (mapv (fn [type]
+                (if-let [existing-type (first (filter #(= (:name type) (:name %)) current-types))]
+                  (merge type existing-type)
+                  (let [type-id (insert-type! tx (assoc type :dataset-id dataset-id))]
+                    (merge type type-id)))))))))
 
 (defn raster-isochrones! [service facility-id]
   (let [scale-resolution 8

--- a/src/planwise/model/import_job.clj
+++ b/src/planwise/model/import_job.clj
@@ -424,7 +424,9 @@
          :state state
          :stats (job-stats job)}
 
-        (:request-sites :importing-sites)
+        (:request-sites :importing-sites
+         :delete-old-facilities :deleting-old-facilities
+         :delete-old-types :deleting-old-types)
         {:status :importing
          :state state
          :progress (import-progress (:value job))}

--- a/src/planwise/model/import_job.clj
+++ b/src/planwise/model/import_job.clj
@@ -99,16 +99,16 @@
 (defn import-sites-succeeded
   [job event & _]
   (let [page (:page job)
-        facility-ids (:facility-ids job)
-        facility-count (count facility-ids)
         [_ _ [_ {:keys [page-ids total-pages sites-without-location sites-without-type]}]] event
-        page-ids (filter some? page-ids)
+        {:keys [new existing moved updated]} page-ids
         total-pages (or total-pages (:page-count job))]
     (-> (complete-task job event)
         (assoc :page (inc page)
-               :page-count total-pages
-               :facility-ids (into facility-ids page-ids)
-               :facility-count (+ facility-count (count page-ids)))
+               :page-count total-pages)
+        (update :facility-ids into (apply concat (vals page-ids)))
+        (update :facility-count + (apply + (map count (vals page-ids))))
+        (update :process-ids concat new moved)
+        (update :process-count + (count new) (count moved))
         (update :sites-without-location-count + (count sites-without-location))
         (update :sites-without-type-count + (count sites-without-type)))))
 
@@ -119,15 +119,45 @@
         (assoc :result :import-sites-failed
                :error-info error))))
 
+(defn dispatch-delete-old-facilities
+  [job & _]
+  (dispatch-task job :delete-old-facilities))
+
+(defn delete-old-facilities-succeeded
+  [job event & _]
+  (complete-task job event))
+
+(defn delete-old-facilities-failed
+  [job event & _]
+  (let [[_ _ error] event]
+    (-> (complete-task job event)
+        (assoc :result :delete-old-facilities-failed
+                       :error-info error))))
+
+(defn dispatch-delete-old-types
+  [job & _]
+  (dispatch-task job :delete-old-types))
+
+(defn delete-old-types-succeeded
+  [job event & _]
+  (complete-task job event))
+
+(defn delete-old-types-failed
+  [job event & _]
+  (let [[_ _ error] event]
+    (-> (complete-task job event)
+        (assoc :result :delete-old-types-failed
+                       :error-info error))))
+
 (defn dispatch-process-facilities
   [job & _]
-  (let [facility-ids (:facility-ids job)
-        next-facility (first facility-ids)]
+  (let [process-ids (:process-ids job)
+        next-facility (first process-ids)]
     (if (nil? next-facility)
       (clear-dispatch job)
       (-> job
           (dispatch-task [:process-facilities [next-facility]])
-          (update :facility-ids rest)))))
+          (update :process-ids rest)))))
 
 (defn dispatch-update-projects
   [job & _]
@@ -199,7 +229,7 @@
 
 (defn done-processing?
   [[job event]]
-  (and (empty? (:facility-ids job))
+  (and (empty? (:process-ids job))
        (process-report? event)
        (last-task-report? [job event])))
 
@@ -214,7 +244,9 @@
    :page           1
    :page-count     1
    :facility-count 0
+   :process-count  0
    :facility-ids   []
+   :process-ids    []
    :tasks          []
    :pending-tasks  []
    :next-task      nil
@@ -246,11 +278,35 @@
    [:importing-sites
     [_ :guard page-number-mismatch?] -> {:action unexpected-event} :error
     [[_ [:success [:import-sites _] [:continue _]]]]  -> {:action import-sites-succeeded} :request-sites
-    [[_ [:success [:import-sites _] _]]]              -> {:action import-sites-succeeded} :update-projects
+    [[_ [:success [:import-sites _] _]]]              -> {:action import-sites-succeeded} :delete-old-facilities
     [[_ [:failure [:import-sites _] _]]]              -> {:action import-sites-failed} :clean-up
     [[_ :next]]                      -> {:action clear-dispatch} :importing-sites
     [[_ :cancel]]                    -> {:action cancel-import} :cancelling
     [[_ _]]                          -> {:action unexpected-event} :error]
+
+   [:delete-old-facilities
+    [[_ :next]]                      -> {:action dispatch-delete-old-facilities} :deleting-old-facilities
+    [[_ :cancel]]                    -> {:action cancel-import} :clean-up
+    [[_ _]]                          -> {:action unexpected-event} :error]
+
+   [:deleting-old-facilities
+    [[_ :next]]                               -> {:action clear-dispatch} :deleting-old-facilities
+    [[_ :cancel]]                             -> {:action cancel-import} :clean-up-wait
+    [[_ [:success :delete-old-facilities _]]] -> {:action delete-old-facilities-succeeded} :delete-old-types
+    [[_ [:failure :delete-old-facilities _]]] -> {:action delete-old-facilities-failed} :error
+    [[_ _]]                                   -> {:action unexpected-event} :error]
+
+   [:delete-old-types
+    [[_ :next]]                      -> {:action dispatch-delete-old-types} :deleting-old-types
+    [[_ :cancel]]                    -> {:action cancel-import} :clean-up
+    [[_ _]]                          -> {:action unexpected-event} :error]
+
+   [:deleting-old-types
+    [[_ :next]]                          -> {:action clear-dispatch} :deleting-old-types
+    [[_ :cancel]]                        -> {:action cancel-import} :clean-up-wait
+    [[_ [:success :delete-old-types _]]] -> {:action delete-old-types-succeeded} :update-projects
+    [[_ [:failure :delete-old-types _]]] -> {:action delete-old-types-failed} :error
+    [[_ _]]                              -> {:action unexpected-event} :error]
 
    [:update-projects
     [[_ :next]]                      -> {:action dispatch-update-projects} :updating-projects
@@ -327,6 +383,10 @@
   [job]
   (get-in job [:value :type-field]))
 
+(defn job-facility-ids
+  [job]
+  (get-in job [:value :facility-ids]))
+
 (defn job-finished?
   [job]
   (or (nil? job)
@@ -338,10 +398,10 @@
     (/ (dec page) page-count)))
 
 (defn- process-progress
-  [{:keys [facility-ids facility-count tasks]}]
-  (when (some-> facility-count pos?)
-    (let [pending-ids (+ (count tasks) (count facility-ids))]
-      (- 1 (/ pending-ids facility-count)))))
+  [{:keys [process-ids process-count tasks]}]
+  (when (some-> process-count pos?)
+    (let [pending-ids (+ (count tasks) (count process-ids))]
+      (- 1 (/ pending-ids process-count)))))
 
 (defn job-status
   [job]

--- a/src/planwise/util/collections.clj
+++ b/src/planwise/util/collections.clj
@@ -1,0 +1,5 @@
+(ns planwise.util.collections)
+
+(defn find-by
+  [coll field value]
+  (reduce #(when (= value (field %2)) (reduced %2)) nil coll))

--- a/test/planwise/component/importer_test.clj
+++ b/test/planwise/component/importer_test.clj
@@ -1,6 +1,8 @@
 (ns planwise.component.importer-test
   (:require [planwise.component.importer :as importer]
             [planwise.component.datasets :as datasets]
+            [planwise.component.facilities :as facilities]
+            [planwise.component.projects :as projects]
             [planwise.boundary.resmap :as resmap]
             [planwise.model.import-job :as import-job]
             [planwise.component.taskmaster :as taskmaster]
@@ -9,7 +11,9 @@
             [clojure.test :refer :all]
             [taoensso.timbre :as timbre]
             [com.stuartsierra.component :as component]
-            [clojure.core.async :refer [chan <! >!] :as async]))
+            [clojure.core.async :refer [chan <! >!] :as async]
+            [clojure.java.jdbc :as jdbc]
+            [planwise.test-utils :refer [make-point]]))
 
 (def resmap-type-field
   {:name "Type",
@@ -27,11 +31,36 @@
     [{:id 1 :name "dataset1" :description "" :owner_id 1 :collection_id 1 :import_mappings nil}
      {:id 2 :name "dataset2" :description "" :owner_id 1 :collection_id 2 :import_mappings nil}]]])
 
-(defn mock-resmap []
+(def fixture-data-with-facilities
+  [[:users
+    [{:id 1 :email "john@doe.com" :full_name "John Doe" :last_login nil :created_at (time/ago (time/minutes 5))}]]
+   [:datasets
+    [{:id 1 :name "dataset1" :description "" :owner_id 1 :collection_id 1 :import_mappings nil}
+     {:id 2 :name "dataset2" :description "" :owner_id 1 :collection_id 2 :import_mappings nil}]]
+   [:facility_types
+    [{:id 1 :dataset_id 1 :name "Hospital"}
+     {:id 2 :dataset_id 1 :name "Rural"}]]
+   [:facilities
+    [{:id 1 :dataset_id 1 :site_id 1 :name "Facility A" :type_id 1 :lat -3   :lon 42 :the_geom (make-point -3 42)   :processing_status "ok"}
+     {:id 2 :dataset_id 1 :site_id 2 :name "Facility B" :type_id 1 :lat -3.5 :lon 42 :the_geom (make-point -3.5 42) :processing_status "ok"}
+     {:id 3 :dataset_id 1 :site_id 3 :name "Facility C" :type_id 1 :lat -3.5 :lon 42 :the_geom (make-point -3.5 42) :processing_status "ok"}]]
+   [:facilities_polygons
+    [{:id 1 :facility_id 1 :threshold 900 :method "alpha-shape"}]]])
+
+
+(def user-ident
+  {:user-email "john@doe.com", :user-id 1})
+
+(defn execute-sql
+  [system sql]
+  (jdbc/execute! (get-in system [:db :spec]) sql))
+
+(defn mock-resmap [{sites :sites}]
   (reify resmap/Resmap
     (get-collection-sites
-      [service user-ident coll-id params]
-      [])
+      [service user-ident coll-id {page :page}]
+      {:sites (if (= 1 page) sites [])
+       :totalPages (if sites 1 0)})
 
     (find-collection-field
       [service user-ident coll-id field-id]
@@ -45,25 +74,104 @@
       (recur))
     channel))
 
+(defn run-tasks
+  [dispatcher]
+  (loop []
+    (when-let [{:keys [task-id task-fn]} (taskmaster/next-task dispatcher)]
+      (let [result (task-fn)]
+        (taskmaster/task-completed dispatcher task-id result)
+        (recur)))))
+
 (defn importer-service [system]
   (-> (importer/importer)
-    (merge (select-keys system [:taskmaster :datasets :resmap]))
+    (merge (select-keys system [:taskmaster :datasets :resmap :facilities :projects]))
     (component/start)))
 
-(defn system []
+(defn system [& [{sites :sites, data :data}]]
   (into
-    (test-system {:fixtures {:data fixture-data}})
+    (test-system {:fixtures {:data (or data fixture-data)}})
     {:taskmaster (mock-taskmaster)
-     :resmap (mock-resmap)
-     :datasets (component/using (datasets/datasets-store) [:db])}))
+     :resmap (mock-resmap {:sites sites})
+     :datasets (component/using (datasets/datasets-store) [:db])
+     :facilities (component/using (facilities/facilities-service {}) [:db])
+     :projects  (component/using (projects/projects-service) [:db :facilities])}))
+
+
+(deftest run-import
+  (timbre/with-level :warn
+    (with-system (system {:sites [{:id 1, :name "s1", :lat -1.2, :long 36.8,
+                                   :properties {:type "hospital"}}]})
+      (execute-sql system "ALTER SEQUENCE facilities_id_seq RESTART WITH 100")
+      (execute-sql system "ALTER SEQUENCE facility_types_id_seq RESTART WITH 100")
+
+      (let [importer (importer-service system)]
+        (importer/run-import-for-dataset importer 1 user-ident)
+        (run-tasks importer))
+
+      (let [dataset (datasets/find-dataset (:datasets system) 1)]
+        (is (= {:sites-without-location-count 0
+                :sites-without-type-count 0
+                :facilities-without-road-network-count 0
+                :facilities-outside-regions-count 1
+                :result :success}
+               (:import-result dataset))))
+
+      (let [types (facilities/list-types (:facilities system) 1)
+            facilities (facilities/list-facilities (:facilities system) 1 {})
+            [facility] facilities]
+        (is (= (count types) 3))
+        (is (= #{"Hospital" "Health Center" "Dispensary"} (set (map :name types))))
+        (is (= (count facilities) 1))
+        (is (= (select-keys facility [:id :name :lat :lon :type-id])
+               {:id 100 :type-id 100 :name "s1" :lat -1.2M :lon 36.8M}))))))
+
+
+(deftest run-reimport
+  (timbre/with-level :warn
+    (with-system (system {:data fixture-data-with-facilities
+                          :sites [{:id 1, :name "Facility A2", :lat -3.0, :long 42.0, :properties {:type "dispensary"}}
+                                  {:id 2, :name "Facility B2", :lat -1.2, :long 36.8, :properties {:type "hospital"}}
+                                  {:id 4, :name "Facility D",  :lat -1.2, :long 36.8, :properties {:type "health center"}}]})
+
+      (execute-sql system "ALTER SEQUENCE facilities_id_seq RESTART WITH 100")
+      (execute-sql system "ALTER SEQUENCE facility_types_id_seq RESTART WITH 100")
+
+      (let [importer (importer-service system)]
+        (importer/run-import-for-dataset importer 1 user-ident)
+        (run-tasks importer))
+
+      (let [dataset (datasets/find-dataset (:datasets system) 1)]
+        (is (= {:sites-without-location-count 0
+                :sites-without-type-count 0
+                :facilities-without-road-network-count 0
+                :facilities-outside-regions-count 2
+                :result :success}
+               (:import-result dataset))))
+
+      (let [types (facilities/list-types (:facilities system) 1)
+            facilities (facilities/list-facilities (:facilities system) 1 {})]
+        (is (= 3 (count types)))
+        (is (= #{{:name "Hospital" :id 1}
+                 {:name "Health Center" :id 100}
+                 {:name "Dispensary" :id 101}}
+               (set types)))
+
+        (is (= 3 (count facilities)))
+        (is (= #{{:id 1   :type-id 101 :name "Facility A2" :lat -3.0M :lon 42.0M :processing-status "ok"}               ; is updated but not reprocessed
+                 {:id 2   :type-id 1   :name "Facility B2" :lat -1.2M :lon 36.8M :processing-status "outside-regions"}  ; is updated and reprocessed
+                 {:id 100 :type-id 100 :name "Facility D"  :lat -1.2M :lon 36.8M :processing-status "outside-regions"}} ; is created
+               (set (map #(select-keys % [:id :name :lat :lon :type-id :processing-status]) facilities))))))))
+
 
 (deftest resume-importer-job
   (timbre/with-level :warn
     (with-system (system)
+      (let [importer (importer-service system)]
+        (let [[result statūs] (importer/run-import-for-dataset importer 1 user-ident)]))
 
       ; Start new import for a dataset
       (let [importer (importer-service system)]
-        (let [[result statūs] (importer/run-import-for-dataset importer 1 {:user-email "john@doe.com", :user-id 1})]
+        (let [[result statūs] (importer/run-import-for-dataset importer 1 user-ident)]
           (is (= :ok result))
           (is (= :importing (:status (get statūs 1)))))
 
@@ -91,12 +199,13 @@
 
       ; Create import job for a dataset with a processing-facilities state
       (let [importer (importer-service system)
-            user-ident {:user-email "john@doe.com", :user-id 1}
             job (import-job/restore-job {:state :processing-facilities
                                          :value (merge import-job/default-job-value
                                                   {:page-count 1, :collection-id 1, :dataset-id 1,
                                                    :type-field {:code "type", :options {}},
                                                    :page 1, :user-ident user-ident,
+                                                   :process-ids [1 2 3 4 5 6],
+                                                   :process-count 6,
                                                    :facility-ids [1 2 3 4 5 6],
                                                    :facility-count 6})})]
         (swap! (:jobs importer) assoc 1 job)

--- a/test/planwise/test_utils.clj
+++ b/test/planwise/test_utils.clj
@@ -3,3 +3,6 @@
 
 (defn sample-polygon []
   (PGgeometry. (str "SRID=4326;MULTIPOLYGON(((1 1, 1 2, 2 2, 2 1, 1 1)))")))
+
+(defn make-point [lat lon]
+  (PGgeometry. (str "SRID=4326;POINT(" lon " " lat ")")))


### PR DESCRIPTION
Support running a reimport from resmap for a dataset. Sites and types insertion is now an upsert, and inserts/updates records as needed. New steps are added to the import job FSM to delete stale types and facilities.

An Update button has been added to the datasets list as well, to trigger an update operation.

Fixes #180