### PR TITLE
Add capacity to facilities

### DIFF
--- a/resources/migrations/033-add_capacity_to_facilities.down.sql
+++ b/resources/migrations/033-add_capacity_to_facilities.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE facilities DROP COLUMN capacity;

--- a/resources/migrations/033-add_capacity_to_facilities.up.sql
+++ b/resources/migrations/033-add_capacity_to_facilities.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE facilities ADD COLUMN capacity INTEGER DEFAULT 0;

--- a/resources/planwise/sql/facilities.sql
+++ b/resources/planwise/sql/facilities.sql
@@ -121,7 +121,8 @@ WHERE id = :facility-polygon-id;
 -- :name select-polygons-in-region :?
 SELECT fp.id AS "facility-polygon-id",
        fp.population AS "facility-population",
-       fpr.population AS "facility-region-population"
+       fpr.population AS "facility-region-population",
+       facilities.capacity AS "capacity"
 FROM facilities_polygons_regions AS fpr
   INNER JOIN facilities_polygons AS fp ON fpr.facility_polygon_id = fp.id
   INNER JOIN facilities ON facilities.id = fp.facility_id

--- a/src/planwise/boundary/facilities.clj
+++ b/src/planwise/boundary/facilities.clj
@@ -20,7 +20,7 @@
    [this dataset-id isochrone-options criteria]
    "Returns the facilities polygons in the criteria's :region, for the facilities
     that satisfy the specified criteria. Includes fields :facility-polygon-id,
-    :facility-population, :facility-region-population.")
+    :facility-population, :facility-region-population and :capacity.")
 
   (list-types [this dataset-id]
     "Lists all the facility types in the dataset."))

--- a/src/planwise/component/facilities.clj
+++ b/src/planwise/component/facilities.clj
@@ -80,10 +80,11 @@
 
 (defn polygons-in-region
   [service dataset-id isochrone-options criteria]
-  (select-polygons-in-region (get-db service) (assoc (isochrone-params isochrone-options)
-                                               :dataset-id dataset-id
-                                               :region-id (:region criteria)
-                                               :criteria (criteria-snip criteria))))
+  (select-polygons-in-region (get-db service)
+                             (assoc (isochrone-params isochrone-options)
+                                    :dataset-id dataset-id
+                                    :region-id (:region criteria)
+                                    :criteria (criteria-snip criteria))))
 
 (defn list-types [service dataset-id]
   (select-types-in-dataset (get-db service) {:dataset-id dataset-id}))

--- a/src/planwise/component/maps.clj
+++ b/src/planwise/component/maps.clj
@@ -47,8 +47,8 @@
   (apply data-path service (cons "isochrones/" args)))
 
 (defn- capacity-for
-  [service {:keys [population population-in-region]}]
-  (let [capacity (default-capacity service)
+  [service {:keys [population population-in-region capacity]}]
+  (let [capacity (or capacity (default-capacity service))
         factor   (/ population-in-region population)]
     (int (* factor capacity))))
 

--- a/test/planwise/component/facilities_test.clj
+++ b/test/planwise/component/facilities_test.clj
@@ -94,7 +94,7 @@
     [{:id 1 :country "C" :name "R1" :the_geom (PGgeometry. (str "SRID=4326;MULTIPOLYGON(((0 0, 0 1, 1 1, 1 0, 0 0)))"))}
      {:id 2 :country "C" :name "R2" :the_geom (PGgeometry. (str "SRID=4326;MULTIPOLYGON(((2 2, 2 3, 3 3, 3 2, 2 2)))"))}]]
    [:facilities
-    [{:id 1 :dataset_id 1 :site_id 1 :name "Facility A" :type_id 1 :lat 0.5 :lon 0.5 :the_geom (make-point 0.5 0.5)}
+    [{:id 1 :dataset_id 1 :site_id 1 :name "Facility A" :type_id 1 :lat 0.5 :lon 0.5 :the_geom (make-point 0.5 0.5) :capacity 500}
      {:id 2 :dataset_id 2 :site_id 2 :name "Facility B" :type_id 1 :lat 0.5 :lon 0.5 :the_geom (make-point 0.5 0.5)}
      {:id 3 :dataset_id 1 :site_id 3 :name "Facility C" :type_id 2 :lat 0.5 :lon 0.5 :the_geom (make-point 0.5 0.5)}
      {:id 4 :dataset_id 1 :site_id 4 :name "Facility D" :type_id 1 :lat 2.5 :lon 2.5 :the_geom (make-point 2.5 2.5)}]]
@@ -119,7 +119,8 @@
     (let [service (:facilities system)
           polygons (facilities/polygons-in-region service 1 {:threshold 900 :algorithm "alpha-shape"} {:region 1 :types [1]})]
       (is (= 1 (count polygons)))
-      (let [[{:keys [facility-polygon-id facility-population facility-region-population]}] polygons]
+      (let [[{:keys [facility-polygon-id facility-population facility-region-population capacity]}] polygons]
         (is (= 1 facility-polygon-id))
         (is (= 2000 facility-population))
-        (is (= 1000 facility-region-population))))))
+        (is (= 1000 facility-region-population))
+        (is (= 500 capacity))))))


### PR DESCRIPTION
Closes #238

- Add a capacity field to the facilities table
- Use said capacity when computing unsatisfied population under the
  isochrone for the facility