### PR TITLE
Finish job when there are no facilities to process

### DIFF
--- a/src/planwise/component/importer.clj
+++ b/src/planwise/component/importer.clj
@@ -262,6 +262,7 @@
            :task-fn (build-task-fn component ready-job task)})
         (do
           (debug (str "Importer: no more tasks to execute"))
+          (swap! (:jobs component) (jobs-finisher component))
           nil))))
 
   (task-completed [component [job-id task-id] result]

--- a/test/planwise/model/import_job_test.clj
+++ b/test/planwise/model/import_job_test.clj
@@ -158,7 +158,19 @@
             (is (= (reduce-job job [:next :cancel])
                    [:clean-up-wait nil :cancelled]))
             (is (= (reduce-job job [:next :cancel [:success [:process-facilities [1]] nil]])
-                   [:error nil :cancelled])))))))))
+                   [:error nil :cancelled])))))
+
+       ;; Alternate path: no facilities were imported
+       (let [job (reduce fsm/fsm-event job [:next
+                                            [:success [:import-sites 1] [nil (page-result {:page-ids {} :total-pages 1})]]
+                                            :next
+                                            [:success :delete-old-facilities nil]
+                                            :next
+                                            [:success :delete-old-types nil]
+                                            :next
+                                            [:success :update-projects nil]])]
+         (is (= (reduce-job job [:next])
+                [:done nil :success])))))))
 
     ;; TODO: test error conditions in all stages
     ;; TODO: test cancellation in all stages


### PR DESCRIPTION
Add a transition to the import job FSM in which when a :next message
arrives and there are no tasks and no pending facilities to process,
finishes the import process successfully. Also, run the job finisher
at the end of the next-task function when there are no more tasks to
execute to handle this exact case.