### PR TITLE
Change tooltip/legend for cancelled datasets

### DIFF
--- a/resources/sass/_datasets.scss
+++ b/resources/sass/_datasets.scss
@@ -154,11 +154,8 @@ article.datasets {
     color: $orange;
     fill: $orange;
   }
+  &.error,
   &.cancelled {
-    color: $orange;
-    fill: $orange;
-  }
-  &.error {
     color: $red;
     fill: $red;
   }

--- a/src/planwise/client/datasets/api.cljs
+++ b/src/planwise/client/datasets/api.cljs
@@ -51,7 +51,7 @@
 (defn cancel-import!
   [dataset-id & handlers]
   (POST "/api/datasets/cancel"
-      (json-request {:dataset-id dataset-id} handlers)))
+      (json-request {:dataset-id dataset-id} handlers :mapper-fn (partial map map-dataset))))
 
 (defn delete-dataset!
   [dataset-id & handlers]

--- a/src/planwise/client/datasets/components/listing.cljs
+++ b/src/planwise/client/datasets/components/listing.cljs
@@ -77,7 +77,10 @@
               :unexpected-event "Import failed"
               nil)]
     (case result
-      (:success :cancelled) (str text ", with " (utils/pluralize warnings-count "warning"))
+      (:success :cancelled)
+      (if (pos? warnings-count)
+        (str text ", with " (utils/pluralize warnings-count "warning"))
+        text)
       text)))
 
 (defn- status-string
@@ -98,7 +101,10 @@
              no-road-network :facilities-without-road-network-count
              no-location :sites-without-location-count
              no-type :sites-without-type-count} import-result
-            warnings-count (+ no-regions no-road-network no-location no-type)]
+            warnings-count (+ no-regions no-road-network no-location no-type)
+            show-popover? (and (not importing?)
+                               (not cancelling?)
+                               (pos? warnings-count))]
         [:div.dataset-card
          [:h1 name]
          [:h2 description]
@@ -107,10 +113,10 @@
           :position :below-left
           :anchor [:p.dataset-status
                    {:class (dataset->status-class dataset)
-                    :on-mouse-over (handler-fn (reset! showing-warnings? (pos? warnings-count)))
+                    :on-mouse-over (handler-fn (reset! showing-warnings? show-popover?))
                     :on-mouse-out (handler-fn (reset! showing-warnings? false))}
                    [common/icon (dataset->status-icon dataset) "icon-small"]
-                   (utils/pluralize facility-count "facility" "facilities")
+                   (utils/pluralize (or facility-count 0) "facility" "facilities")
                    (when-let [status (status-string server-status result warnings-count)]
                     (str " (" status ")"))]
           :popover [popover/popover-content-wrapper

--- a/src/planwise/client/datasets/components/status_helpers.cljs
+++ b/src/planwise/client/datasets/components/status_helpers.cljs
@@ -16,9 +16,9 @@
   "Returns a status icon relative to the dataset status"
   [dataset]
   (case (dataset->status dataset)
-    (nil :success :importing) :location
-    (:cancelled :warn)        :warning
-    (:error :unknown)         :remove-circle
+    (nil :success :importing)    :location
+    (:warn)                      :warning
+    (:cancelled :error :unknown) :remove-circle
     nil))
 
 (defn dataset->status-class


### PR DESCRIPTION
Fixes #230

- Remove the warnings text when no warnings occurred
- Show the red stop icon when the dataset was cancelled
- Map the result of the cancel import request
- Hide popover while importing/cancelling

![screen shot 2016-09-22 at 19 44 40](https://cloud.githubusercontent.com/assets/733591/18768633/161db9f2-80fd-11e6-8e17-2ac2858aaab8.png)
