### PR TITLE
Process unprocessed facilities on a dataset reimport

### DIFF
--- a/src/planwise/component/importer.clj
+++ b/src/planwise/component/importer.clj
@@ -127,8 +127,8 @@
         (info (str "Dataset " dataset-id ": "
                    "Inserting " (count new-facilities) " facilities from page " page
                    " of collection " coll-id))
-        (let [new-ids (facilities/insert-facilities! facilities dataset-id new-facilities)]
-          [:continue {:page-ids new-ids
+        (let [new-facilities (facilities/insert-facilities! facilities dataset-id new-facilities)]
+          [:continue {:page-facilities new-facilities
                       :total-pages total-pages
                       :sites-without-location sites-without-location
                       :sites-without-type sites-without-type}])))))

--- a/src/planwise/model/import_job.clj
+++ b/src/planwise/model/import_job.clj
@@ -99,16 +99,17 @@
 (defn import-sites-succeeded
   [job event & _]
   (let [page (:page job)
-        [_ _ [_ {:keys [page-ids total-pages sites-without-location sites-without-type]}]] event
-        {:keys [new existing moved updated]} page-ids
+        [_ _ [_ {:keys [page-facilities total-pages sites-without-location sites-without-type]}]] event
+        page-facilities-to-process (filter #(or (= :moved (:insertion-status %))
+                                                (nil? (:processing-status %))) page-facilities)
         total-pages (or total-pages (:page-count job))]
     (-> (complete-task job event)
         (assoc :page (inc page)
                :page-count total-pages)
-        (update :facility-ids into (apply concat (vals page-ids)))
-        (update :facility-count + (apply + (map count (vals page-ids))))
-        (update :process-ids concat new moved)
-        (update :process-count + (count new) (count moved))
+        (update :facility-ids into (map :id page-facilities))
+        (update :facility-count + (count page-facilities))
+        (update :process-ids into (map :id page-facilities-to-process))
+        (update :process-count + (count page-facilities-to-process))
         (update :sites-without-location-count + (count sites-without-location))
         (update :sites-without-type-count + (count sites-without-type)))))
 


### PR DESCRIPTION
If a dataset is cancelled and then reimported, ensure those facilities that were not processed in the first run are indeed processed.

Change the return type of insert-facilities so it returns a list of all the new facilities inserted, along with an inserted-status attribute that yields whether it's new, moved, existing or updated.

Fixes #250