### PR TITLE
Fix deploy step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
             - ~/cache/.m2
 
   deploy:
-    <<: *environment
+    machine: true
     steps:
       - run:
           <<: *install-docker-compose

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -3,7 +3,9 @@ FROM clojure:lein-2.8.1
 RUN apt update && \
     apt install -y build-essential libboost-program-options-dev libpq-dev \
                    libgdal-dev postgresql-client libpq-dev gdal-bin python-gdal libgdal-java \
-                   osm2pgrouting
+                   osm2pgrouting && \
+    curl -sL https://deb.nodesource.com/setup_9.x | bash - && \
+    apt-get install -y nodejs
 
 WORKDIR /app
 

--- a/dev/resources/dev.edn
+++ b/dev/resources/dev.edn
@@ -11,6 +11,7 @@
             :build-options {:main cljs.user
                             :parallel-build true
                             :install-deps true
+                            :language-in :es-2016
                             :npm-deps #ig/ref :planwise.config/npm-deps
                             :output-to "target/resources/planwise/public/js/main.js"
                             :output-dir "target/resources/planwise/public/js"

--- a/dev/resources/dev.edn
+++ b/dev/resources/dev.edn
@@ -11,8 +11,7 @@
             :build-options {:main cljs.user
                             :parallel-build true
                             :install-deps true
-                            :npm-deps { :material-components-web "0.32.0"
-                                        :rmwc "1.4.0"}
+                            :npm-deps #ig/ref :planwise.config/npm-deps
                             :output-to "target/resources/planwise/public/js/main.js"
                             :output-dir "target/resources/planwise/public/js"
                             :asset-path "/js"

--- a/resources/planwise/config.edn
+++ b/resources/planwise/config.edn
@@ -14,6 +14,10 @@
   :output-style  :compressed
   :build-order   #ig/ref :duct.compiler/cljs}
 
+ :planwise.config/npm-deps
+ {:material-components-web "0.32.0"
+  :rmwc "1.4.0"}
+
  ;; Database
 
  :planwise.database/migrations

--- a/resources/planwise/prod.edn
+++ b/resources/planwise/prod.edn
@@ -7,8 +7,7 @@
              :output-to       "target/resources/planwise/public/js/main.js"
              :output-dir      "target/resources/planwise/public/js"
              :install-deps    true
-             :npm-deps        {:material-components-web "0.32.0"
-                               :rmwc "1.4.0"}
+             :npm-deps        #ig/ref :planwise.config/npm-deps
              :asset-path      "/js"
              :closure-defines {goog.DEBUG false}
              :externs         ["resources/planwise/externs.js"]

--- a/resources/planwise/prod.edn
+++ b/resources/planwise/prod.edn
@@ -6,10 +6,11 @@
             {:main            planwise.client.core
              :output-to       "target/resources/planwise/public/js/main.js"
              :output-dir      "target/resources/planwise/public/js"
+             :language-in     :es-2016
              :install-deps    true
              :npm-deps        #ig/ref :planwise.config/npm-deps
              :asset-path      "/js"
              :closure-defines {goog.DEBUG false}
              :externs         ["resources/planwise/externs.js"]
              :verbose         true
-             :optimizations   :advanced}}]}}
+             :optimizations   :simple}}]}}

--- a/resources/planwise/prod.edn
+++ b/resources/planwise/prod.edn
@@ -6,6 +6,9 @@
             {:main            planwise.client.core
              :output-to       "target/resources/planwise/public/js/main.js"
              :output-dir      "target/resources/planwise/public/js"
+             :install-deps    true
+             :npm-deps        {:material-components-web "0.32.0"
+                               :rmwc "1.4.0"}
              :asset-path      "/js"
              :closure-defines {goog.DEBUG false}
              :externs         ["resources/planwise/externs.js"]

--- a/src/planwise/config.clj
+++ b/src/planwise/config.clj
@@ -1,5 +1,6 @@
 (ns planwise.config
   (:require [duct.core.env :as env]
+            [integrant.core :as ig]
             ;; Force load SASS compiler component for key derivation declaration
             [duct.compiler.sass]
             [clojure.java.io :as io]
@@ -14,3 +15,5 @@
               str/trim-newline
               str/trim)
       "development"))
+
+(defmethod ig/init-key :planwise.config/npm-deps [_ options] options)

--- a/src/planwise/config.clj
+++ b/src/planwise/config.clj
@@ -3,6 +3,7 @@
             [integrant.core :as ig]
             ;; Force load SASS compiler component for key derivation declaration
             [duct.compiler.sass]
+            [planwise.sass]
             [clojure.java.io :as io]
             [clojure.string :as str]))
 

--- a/src/planwise/sass.clj
+++ b/src/planwise/sass.clj
@@ -74,3 +74,5 @@
     (doseq [[in out] in->out]
       (compile-sass in out opts))
     (mapv (comp str val) in->out)))
+
+(derive :planwise/sass :duct/compiler)


### PR DESCRIPTION
Disable docker layer cache for deploy step
Install npm

The node packages to install are now duplicated in `prod.edn` and `dev.edn`. I am not sure what would be an idiomatic way to DRY here.

Fix #300 