### PR TITLE
Improvements to client build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM openjdk:8-jre
 # Install package dependencies and add precompiled binary
 RUN for i in {1..5}; do \
        (apt-get update \
-        && apt-get -y install postgresql-client libboost-program-options-dev libpq-dev gdal-bin python-gdal libgdal-java osm2pgrouting \
+        && apt-get -y install postgresql-client gdal-bin python-gdal libgdal-java osm2pgrouting \
         && break) \
        || (sleep 5; false); done \
   && apt-get clean \

--- a/README.md
+++ b/README.md
@@ -226,11 +226,16 @@ $ make clean all
 
 ### Node modules
 
-Install NPM dependencies before firing up the REPL:
+NPM dependencies are handled by `npm` and updated via the `package.json` file.
+
+Install NPM dependencies before firing up the REPL or compiling the project:
 
 ```sh
 $ npm install
 ```
+
+NB: `npm install` is ran automatically when executing `(go)` from the REPL.
+
 
 ## Development workflow with the REPL
 

--- a/README.md
+++ b/README.md
@@ -224,6 +224,14 @@ $ cd cpp
 $ make clean all
 ```
 
+### Node modules
+
+Install NPM dependencies before firing up the REPL:
+
+```sh
+$ npm install
+```
+
 ## Development workflow with the REPL
 
 Connect to the running REPL inside the Docker container from your editor/IDE or

--- a/deploy.sh
+++ b/deploy.sh
@@ -9,6 +9,7 @@ if [ $# -lt 1 ]; then
 fi
 
 git describe --always > resources/planwise/version
+docker-compose run --rm app npm install
 docker-compose run --rm app lein uberjar
 docker-compose run --rm app make -C cpp release
 

--- a/dev/resources/dev.edn
+++ b/dev/resources/dev.edn
@@ -10,9 +10,8 @@
             :source-paths  ["dev/src" "src"]
             :build-options {:main cljs.user
                             :parallel-build true
-                            :install-deps false
                             :language-in :es-2016
-                            :npm-deps #ig/ref :planwise.config/npm-deps
+                            :npm-deps true
                             :output-to "target/resources/planwise/public/js/main.js"
                             :output-dir "target/resources/planwise/public/js"
                             :asset-path "/js"
@@ -20,11 +19,12 @@
                                               "re_frame.trace.trace_enabled_QMARK_" true}
                             :verbose false
                             :preloads [devtools.preload]
-                            :optimizations :none}}]}
+                            :optimizations :none}}]
+  :build-order #ig/ref :planwise/sass}
 
  :planwise/sass
  {:output-style :nested
-  :build-order   #ig/ref :duct.server/figwheel}
+  :source-map?  true}
 
  :duct.module/sql
  {:database-url #duct/env ["DATABASE_URL" Str :or "jdbc:postgresql://localhost:5433/planwise?user=planwise&password=planwise"]}

--- a/dev/resources/dev.edn
+++ b/dev/resources/dev.edn
@@ -10,7 +10,7 @@
             :source-paths  ["dev/src" "src"]
             :build-options {:main cljs.user
                             :parallel-build true
-                            :install-deps true
+                            :install-deps false
                             :language-in :es-2016
                             :npm-deps #ig/ref :planwise.config/npm-deps
                             :output-to "target/resources/planwise/public/js/main.js"

--- a/dev/src/dev.clj
+++ b/dev/src/dev.clj
@@ -10,7 +10,7 @@
             [eftest.runner :as eftest]
             [clojure.spec.alpha :as s]
             [integrant.core :as ig]
-            [integrant.repl :refer [clear halt go init prep reset]]
+            [integrant.repl :refer [clear halt init prep reset]]
             [integrant.repl.state :refer [config system]]
             [taoensso.timbre :as timbre]
             [planwise.config]

--- a/dev/src/planwise/repl.clj
+++ b/dev/src/planwise/repl.clj
@@ -4,6 +4,7 @@
             [integrant.repl :as igr]
             [integrant.repl.state :refer [config system]]
             [duct.server.figwheel :as figwheel]
+            [figwheel-sidecar.utils :as fig-utils]
             [eftest.runner :as eftest]
             [planwise.database :as database]
             [planwise.tasks.build-icons :as build-icons]
@@ -24,6 +25,14 @@
   []
   (let [figwheel (:duct.server/figwheel system)]
     (figwheel/rebuild-cljs figwheel)))
+
+(defn clean-cljs
+  []
+  (let [builds (get-in config [:duct.server/figwheel :builds])]
+    (dorun (for [{:keys [build-options]} builds]
+             (do
+               (println "Cleaning CLJS in" (:output-dir build-options))
+               (fig-utils/clean-cljs-build* build-options))))))
 
 (defn run-tests
   [tests]

--- a/dev/src/planwise/repl.clj
+++ b/dev/src/planwise/repl.clj
@@ -1,6 +1,7 @@
 (ns planwise.repl
   (:refer-clojure :exclude [test])
   (:require [integrant.core :as ig]
+            [integrant.repl :as igr]
             [integrant.repl.state :refer [config system]]
             [duct.server.figwheel :as figwheel]
             [eftest.runner :as eftest]
@@ -10,7 +11,8 @@
             [ragtime.jdbc :as rag-jdbc]
             [duct.migrator.ragtime :as dmr]
             [planwise.boundary.facilities :as facilities]
-            [buddy.core.nonce :as nonce])
+            [buddy.core.nonce :as nonce]
+            [clojure.java.shell :as shell])
   (:import org.apache.commons.codec.binary.Hex))
 
 (defn db
@@ -71,3 +73,18 @@
   (-> (nonce/random-bytes 32)
       Hex/encodeHex
       String.))
+
+(defn npm-install
+  []
+  (println "Running npm install...")
+  (let [{:keys [exit out err]} (shell/sh "npm" "install")]
+    (cond (zero? exit) (println out)
+          :else (do
+                  (println "Error running npm install - exit code" exit)
+                  (print err)))))
+
+(defn go
+  []
+  (npm-install)
+  (igr/prep)
+  (igr/init))

--- a/package-lock.json
+++ b/package-lock.json
@@ -706,7 +706,7 @@
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "requires": {
         "node-fetch": "1.7.3",
-        "whatwg-fetch": "2.0.3"
+        "whatwg-fetch": "2.0.4"
       }
     },
     "js-tokens": {
@@ -1019,11 +1019,6 @@
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
     },
-    "trim": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
-    },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -1040,9 +1035,9 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "whatwg-fetch": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
     },
     "xtend": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -3,9 +3,8 @@
     "@cljs-oss/module-deps": "^1.1.1",
     "create-react-class": "^15.6.3",
     "material-components-web": "^0.32.0",
-    "react": "^15.5.4",
-    "react-dom": "^15.5.4",
-    "rmwc": "^1.4.1",
-    "trim": "0.0.1"
+    "react": "=15.5.4",
+    "react-dom": "=15.5.4",
+    "rmwc": "^1.4.1"
   }
 }

--- a/project.clj
+++ b/project.clj
@@ -97,8 +97,8 @@
   :prep-tasks         ["javac"
                        "compile"
                        ["run" ":duct/compiler"]]
-  :jar-exclusions     [#"^svg/icons/.*" #"^sass/.*" #".*DS_Store$"]
-  :uberjar-exclusions [#"^svg/icons/.*" #"^sass/.*" #".*DS_Store$"]
+  :jar-exclusions     [#"^svg/icons/.*" #"^sass/.*" #".*DS_Store$" #"^planwise/public/js/.*/.*"]
+  :uberjar-exclusions [#"^svg/icons/.*" #"^sass/.*" #".*DS_Store$" #"^planwise/public/js/.*/.*"]
   :uberjar-name       "planwise-standalone.jar"
 
   :aliases {"migrate"               ["with-profile" "+repl" "run" ":duct/migrator"]

--- a/resources/planwise/config.edn
+++ b/resources/planwise/config.edn
@@ -10,13 +10,7 @@
  {:logger        #ig/ref :duct/logger
   :source-paths  ["resources/sass"]
   :include-paths ["node_modules"]
-  :output-path   "target/resources/planwise/public/css"
-  :output-style  :compressed
-  :build-order   #ig/ref :duct.compiler/cljs}
-
- :planwise.config/npm-deps
- {:material-components-web "0.32.0"
-  :rmwc "1.4.1"}
+  :output-path   "target/resources/planwise/public/css"}
 
  ;; Database
 

--- a/resources/planwise/prod.edn
+++ b/resources/planwise/prod.edn
@@ -5,12 +5,15 @@
             :build-options
             {:main            planwise.client.core
              :output-to       "target/resources/planwise/public/js/main.js"
-             :output-dir      "target/resources/planwise/public/js"
+             :output-dir      "target/resources/planwise/public/js/"
+             :source-map      "target/resources/planwise/public/js/main.js.map"
              :language-in     :es-2016
-             :install-deps    true
-             :npm-deps        #ig/ref :planwise.config/npm-deps
              :asset-path      "/js"
              :closure-defines {goog.DEBUG false}
              :externs         ["resources/planwise/externs.js"]
              :verbose         true
-             :optimizations   :simple}}]}}
+             :optimizations   :simple}}]}
+
+ :planwise/sass
+ {:output-style :compressed
+  :build-order  #ig/ref :duct.compiler/cljs}}


### PR DESCRIPTION
- NPM dependencies must be installed explicitly running `npm install`
- Should fix dreaded `nameToPath` errors during development
- Only write CSS if the contents have changed, preventing unnecessary reloads in the client
- Fix run dependency order of SASS and CLJS in development: CLJS (figwheel) depends on SASS since it will notify the browsers of changes in the CSS
- Remove unneeded dependencies in production Docker images, cutting a couple of Mb in the image
- Don't bundle intermediate .js/.cljs files in JARs
