### PR TITLE
Scenarios entity

### DIFF
--- a/resources/migrations/045-scenarios.down.sql
+++ b/resources/migrations/045-scenarios.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS scenarios;

--- a/resources/migrations/045-scenarios.up.sql
+++ b/resources/migrations/045-scenarios.up.sql
@@ -2,6 +2,7 @@ CREATE TABLE IF NOT EXISTS scenarios (
   id BIGSERIAL PRIMARY KEY,
   name VARCHAR(255) NOT NULL,
   "project-id" BIGINT NOT NULL REFERENCES projects2(id),
+  label VARCHAR(255) NULL,
   investment NUMERIC(12, 2) NULL,
   "demand-coverage" BIGINT NULL,
   changeset TEXT NOT NULL

--- a/resources/migrations/045-scenarios.up.sql
+++ b/resources/migrations/045-scenarios.up.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS scenarios (
+  id BIGSERIAL PRIMARY KEY,
+  name VARCHAR(255) NOT NULL,
+  "project-id" BIGINT NOT NULL REFERENCES projects2(id),
+  investment NUMERIC(12, 2) NULL,
+  "demand-coverage" BIGINT NULL,
+  changeset TEXT NOT NULL
+);

--- a/resources/planwise/config.edn
+++ b/resources/planwise/config.edn
@@ -227,5 +227,8 @@
  {:bin         #duct/env ["BIN_PATH" Str :or "bin/"]
   :scripts     #duct/env ["SCRIPTS_PATH" Str :or "scripts/"]}
 
+ :planwise.component/scenarios
+ {:db          #ig/ref :duct.database/sql}
+
  :planwise.component/users
  {:db          #ig/ref :duct.database/sql}}

--- a/resources/planwise/sql/scenarios.sql
+++ b/resources/planwise/sql/scenarios.sql
@@ -1,7 +1,20 @@
 -- :name db-list-scenarios :?
-SELECT id, name, investment, "demand-coverage"
+SELECT id, name, investment, "demand-coverage",
+CASE
+  WHEN name = 'Initial' THEN 'initial'
+  WHEN rank() OVER (ORDER BY "demand-coverage" desc, investment asc) = 1 THEN 'best'
+  WHEN rank() OVER (PARTITION BY investment ORDER BY "demand-coverage" desc) = 1 THEN 'optimal'
+  ELSE NULL
+END as label
 FROM scenarios
 WHERE "project-id" = :project-id
+ORDER BY
+CASE
+  WHEN name = 'Initial' THEN 1
+  WHEN rank() OVER (ORDER BY "demand-coverage" desc, investment asc) = 1 THEN 2
+  WHEN rank() OVER (PARTITION BY investment ORDER BY "demand-coverage" desc) = 1 THEN 3
+  ELSE 4
+END ASC, "demand-coverage" DESC
 
 -- :name db-find-scenario :? :1
 SELECT *

--- a/resources/planwise/sql/scenarios.sql
+++ b/resources/planwise/sql/scenarios.sql
@@ -1,0 +1,23 @@
+-- :name db-list-scenarios :?
+SELECT id, name, investment, "demand-coverage"
+FROM scenarios
+WHERE "project-id" = :project-id
+
+-- :name db-find-scenario :? :1
+SELECT *
+FROM scenarios
+WHERE id = :id
+
+-- :name db-create-scenario! :<! :1
+INSERT INTO scenarios
+  (name, "project-id", investment, "demand-coverage", changeset)
+VALUES
+  (:name, :project-id, :investment, NULL, :changeset)
+RETURNING id;
+
+-- :name db-update-scenario! :! :1
+UPDATE scenarios
+  SET name = :name, investment = :investment,
+  "demand-coverage" = :demand-coverage, changeset = :changeset
+WHERE
+  id = :id

--- a/resources/planwise/sql/scenarios.sql
+++ b/resources/planwise/sql/scenarios.sql
@@ -1,20 +1,31 @@
 -- :name db-list-scenarios :?
-SELECT id, name, investment, "demand-coverage",
-CASE
-  WHEN name = 'Initial' THEN 'initial'
-  WHEN rank() OVER (ORDER BY "demand-coverage" desc, investment asc) = 1 THEN 'best'
-  WHEN rank() OVER (PARTITION BY investment ORDER BY "demand-coverage" desc) = 1 THEN 'optimal'
-  ELSE NULL
-END as label
+SELECT id, name, investment, "demand-coverage", label
 FROM scenarios
 WHERE "project-id" = :project-id
 ORDER BY
 CASE
-  WHEN name = 'Initial' THEN 1
-  WHEN rank() OVER (ORDER BY "demand-coverage" desc, investment asc) = 1 THEN 2
-  WHEN rank() OVER (PARTITION BY investment ORDER BY "demand-coverage" desc) = 1 THEN 3
+  WHEN label = 'initial' THEN 1
+  WHEN label = 'best'    THEN 2
+  WHEN label = 'optimal' THEN 3
   ELSE 4
 END ASC, "demand-coverage" DESC
+
+-- :name db-update-scenarios-label! :!
+UPDATE scenarios
+SET label = computed.label
+FROM (
+  SELECT id,
+    CASE
+    WHEN rank() OVER (ORDER BY "demand-coverage" desc, investment asc) = 1 THEN 'best'
+    WHEN rank() OVER (PARTITION BY investment ORDER BY "demand-coverage" desc) = 1 THEN 'optimal'
+    ELSE NULL
+    END as label
+  FROM scenarios
+  WHERE "project-id" = :project-id
+    AND (label IS NULL OR label <> 'initial')
+    AND "demand-coverage" IS NOT NULL
+) AS computed
+WHERE scenarios.id = computed.id
 
 -- :name db-find-scenario :? :1
 SELECT *
@@ -23,9 +34,9 @@ WHERE id = :id
 
 -- :name db-create-scenario! :<! :1
 INSERT INTO scenarios
-  (name, "project-id", investment, "demand-coverage", changeset)
+  (name, "project-id", investment, "demand-coverage", changeset, label)
 VALUES
-  (:name, :project-id, :investment, NULL, :changeset)
+  (:name, :project-id, :investment, NULL, :changeset, :label)
 RETURNING id;
 
 -- :name db-update-scenario! :! :1

--- a/src/planwise/boundary/scenarios.clj
+++ b/src/planwise/boundary/scenarios.clj
@@ -1,0 +1,19 @@
+(ns planwise.boundary.scenarios)
+
+(defprotocol Scenarios
+  "API for manipulating scenarios"
+
+  (list-scenarios [this project-id]
+    "Returns the list of the scenarios owned by the project")
+
+  (get-scenario [this scenario-id]
+    "Finds a scenario by id")
+
+  (create-initial-scenario [this project-id]
+    "Creates the initial scenario for the given project. Deferred computation will occur.")
+
+  (create-scenario [this project-id props]
+    "Creates an scenario the given project. Deferred computation will occur.")
+
+  (update-scenario [this scenario-id props]
+    "Updates the given scenario. Deferred computation will occur."))

--- a/src/planwise/component/scenarios.clj
+++ b/src/planwise/component/scenarios.clj
@@ -7,7 +7,7 @@
             [hugsql.core :as hugsql]
             [clojure.edn :as edn]
             [clojure.string :as str]
-            [schema.core :as s]))
+            [clojure.spec.alpha :as s]))
 
 (timbre/refer-timbre)
 
@@ -52,7 +52,7 @@
 (defn create-scenario
   [store project-id {:keys [name changeset]}]
   ;; TODO schedule demand computation
-  (s/validate model/ChangeSet changeset)
+  (assert (s/valid? ::model/change-set changeset))
   (db-create-scenario! (get-db store)
     {:name name
      :project-id project-id
@@ -65,7 +65,7 @@
   [store scenario-id {:keys [name changeset]}]
   ;; TODO schedule demand computation
   ;; TODO fail if updating initial. initial scenario should be readonly
-  (s/validate model/ChangeSet changeset)
+  (assert (s/valid? ::model/change-set changeset))
   (let [db (get-db store)
         project-id (:project-id (db-find-scenario db scenario-id))]
     (db-update-scenario! db

--- a/src/planwise/component/scenarios.clj
+++ b/src/planwise/component/scenarios.clj
@@ -1,0 +1,89 @@
+(ns planwise.component.scenarios
+  (:require [planwise.boundary.scenarios :as boundary]
+            [integrant.core :as ig]
+            [taoensso.timbre :as timbre]
+            [clojure.java.jdbc :as jdbc]
+            [hugsql.core :as hugsql]
+            [clojure.edn :as edn]
+            [clojure.string :as str]))
+
+(timbre/refer-timbre)
+
+;; ----------------------------------------------------------------------
+;; Auxiliary and utility functions
+
+(hugsql/def-db-fns "planwise/sql/scenarios.sql")
+
+(defn get-db
+  [store]
+  (get-in store [:db :spec]))
+
+;; ----------------------------------------------------------------------
+;; Service definition
+
+(defn list-scenarios
+  [store project-id]
+  ;; TODO sort by order, compute optimal
+  ;; TODO compute % coverage from initial scenario/project
+  (db-list-scenarios (get-db store) {:project-id project-id}))
+
+(defn get-scenario
+  [store scenario-id]
+  ;; TODO compute % coverage from initial scenario/projects
+  (-> (db-find-scenario (get-db store) {:id scenario-id})
+      (update :changeset edn/read-string)))
+
+(defn create-initial-scenario
+  [store project-id]
+  ;; TODO schedule demand computation
+  (db-create-scenario! (get-db store)
+    {:name "Initial"
+     :project-id project-id
+     :investment 0
+     :changeset "[]"}))
+
+(defn create-scenario
+  [store project-id {:keys [name changeset]}]
+  ;; TODO compute investment from sum
+  ;; TODO validate changeset schema
+  ;; TODO schedule demand computation
+  (db-create-scenario! (get-db store)
+    {:name name
+     :project-id project-id
+     :investment nil
+     :changeset (pr-str changeset)}))
+
+(defn update-scenario
+  [store scenario-id {:keys [name changeset]}]
+  ;; TODO compute investment from sum
+  ;; TODO validate changeset schema
+  ;; TODO schedule demand computation
+  (db-update-scenario! (get-db store)
+    {:name name
+     :id scenario-id
+     :investment nil
+     :changeset (pr-str changeset)}))
+
+(defrecord ScenariosStore [db]
+  boundary/Scenarios
+  (list-scenarios [store project-id]
+    (list-scenarios store project-id))
+  (get-scenario [store scenario-id]
+    (get-scenario store scenario-id))
+  (create-initial-scenario [store project-id]
+    (create-initial-scenario store project-id))
+  (create-scenario [store project-id props]
+    (create-scenario store project-id props))
+  (update-scenario [store scenario-id props]
+    (update-scenario store scenario-id props)))
+
+(defmethod ig/init-key :planwise.component/scenarios
+  [_ config]
+  (map->ScenariosStore config))
+
+(comment
+  ;; REPL testing
+  (def store (:planwise.component/scenarios integrant.repl.state/system))
+
+  (list-scenarios store 1) ; project-id: 1
+  (get-scenario store 2)) ; scenario-id 2

--- a/src/planwise/component/scenarios.clj
+++ b/src/planwise/component/scenarios.clj
@@ -29,7 +29,6 @@
 
 (defn list-scenarios
   [store project-id]
-  ;; TODO sort by order, compute optimal
   ;; TODO compute % coverage from initial scenario/project
   (db-list-scenarios (get-db store) {:project-id project-id}))
 

--- a/src/planwise/model/scenarios.clj
+++ b/src/planwise/model/scenarios.clj
@@ -1,11 +1,14 @@
 (ns planwise.model.scenarios
-  (:require [schema.core :as s]))
+  (:require [clojure.spec.alpha :as s]))
 
-(def CreateSiteChange
-  {:action (s/enum "create-site")
-   :investment s/Int
-   :capacity s/Int
-   :site-id s/Str})
+(s/def ::investment int?)
+(s/def ::capacity int?)
+(s/def ::site-id string?)
 
-(def ChangeSet
-  [CreateSiteChange])
+(s/def :create-site/action #{"create-site"})
+
+(s/def ::create-site-change
+  (s/keys :req-un [:create-site/action ::investment ::capacity ::site-id]))
+
+(s/def ::change-set
+  (s/coll-of ::create-site-change))

--- a/src/planwise/model/scenarios.clj
+++ b/src/planwise/model/scenarios.clj
@@ -1,0 +1,11 @@
+(ns planwise.model.scenarios
+  (:require [schema.core :as s]))
+
+(def CreateSiteChange
+  {:action (s/enum "create-site")
+   :investment s/Int
+   :capacity s/Int
+   :site-id s/Str})
+
+(def ChangeSet
+  [CreateSiteChange])

--- a/test/planwise/component/scenarios_test.clj
+++ b/test/planwise/component/scenarios_test.clj
@@ -1,0 +1,73 @@
+(ns planwise.component.scenarios-test
+  (:require [clojure.test :refer :all]
+            [clojure.java.io :as io]
+            [planwise.component.scenarios :as scenarios]
+            [planwise.model.scenarios :as model]
+            [planwise.test-system :as test-system]
+            [clj-time.core :as time]
+            [integrant.core :as ig]
+            [schema.core :as s]))
+
+(def owner-id 10)
+(def project-id 20)
+
+(def fixture
+  [[:users
+    [{:id owner-id :email "jdoe@example.org"}]]
+   [:projects2
+    [{:id project-id :owner-id owner-id :name "" :config nil :dataset-id nil}]]
+   [:scenarios
+    []]])
+
+(defn test-config
+  ([]
+   (test-config fixture))
+  ([data]
+   (test-system/config
+    {:planwise.test/fixtures       {:fixtures data}
+     :planwise.component/scenarios {:db (ig/ref :duct.database/sql)}})))
+
+;; ----------------------------------------------------------------------
+;; Testing scenario's creation
+
+(deftest empty-list-of-scenarios
+  (test-system/with-system (test-config)
+    (let [store (:planwise.component/scenarios system)
+          scenarios (scenarios/list-scenarios store project-id)]
+      (is (= (count scenarios) 0)))))
+
+(deftest initial-scenario-has-empty-changeset
+  (test-system/with-system (test-config)
+    (let [store       (:planwise.component/scenarios system)
+          scenario-id (:id (scenarios/create-initial-scenario store project-id))
+          scenario    (scenarios/get-scenario store scenario-id)]
+      (is (= (:name scenario) "Initial"))
+      (is (= (:project-id scenario) project-id))
+      (is (= (:changeset scenario) [])))))
+
+(deftest create-scenario-with-new-sites
+  (test-system/with-system (test-config)
+    (let [store       (:planwise.component/scenarios system)
+          first-action {:action "create-site" :site-id "new.1" :investment 10000 :capacity 50}
+          second-action {:action "create-site" :site-id "new.2" :investment 5000 :capacity 20}
+          props       {:name "Foo" :changeset [first-action second-action]}
+          scenario-id (:id (scenarios/create-scenario store project-id props))
+          scenario    (scenarios/get-scenario store scenario-id)]
+      (is (= (:name scenario) (:name props)))
+      (is (= (:project-id scenario) project-id))
+      (is (= (:changeset scenario) (:changeset props)))
+
+      ;; computes sum of investments of actions
+      (is (= (:investment scenario) 15000M)))))
+
+(deftest valid-changeset
+  (let [t #(is (nil? (s/check model/ChangeSet %)))]
+    (t [])
+    (t [{:action "create-site" :site-id "new.1" :investment 10000 :capacity 50}])))
+
+(deftest invalid-changeset
+  (let [t #(is (some? (s/check model/ChangeSet %)))]
+    (t [{:action "unknown-action" :site-id "new.1" :investment 10000 :capacity 50}])
+    (t [{:action "create-site" :site-id "new.1" :investment nil :capacity nil}])
+    (t [{:action "create-site" :site-id "new.1" :investment "" :capacity ""}])
+    (t [{:action "create-site" :site-id "new.1"}])))

--- a/test/planwise/component/scenarios_test.clj
+++ b/test/planwise/component/scenarios_test.clj
@@ -32,11 +32,11 @@
    [:projects2
     [{:id project-id :owner-id owner-id :name "" :config nil :dataset-id nil}]]
    [:scenarios
-    [{:investment 0    :demand-coverage 100 :id initial-scenario-id     :name "Initial" :project-id project-id :changeset "[]"}
-     {:investment 500  :demand-coverage 120 :id sub-optimal-scenario-id :name "S1"      :project-id project-id :changeset "[]"}
-     {:investment 500  :demand-coverage 150 :id best-scenario-id        :name "S2"      :project-id project-id :changeset "[]"}
-     {:investment 1000 :demand-coverage 150 :id optimal-scenario-id     :name "S3"      :project-id project-id :changeset "[]"}
-     {:investment 1000 :demand-coverage 120 :id other-scenario-id       :name "S4"      :project-id project-id :changeset "[]"}]]])
+    [{:investment 0    :demand-coverage 100 :id initial-scenario-id     :label "initial" :name "Initial" :project-id project-id :changeset "[]"}
+     {:investment 500  :demand-coverage 120 :id sub-optimal-scenario-id :label nil       :name "S1"      :project-id project-id :changeset "[]"}
+     {:investment 500  :demand-coverage 150 :id best-scenario-id        :label nil       :name "S2"      :project-id project-id :changeset "[]"}
+     {:investment 1000 :demand-coverage 150 :id optimal-scenario-id     :label nil       :name "S3"      :project-id project-id :changeset "[]"}
+     {:investment 1000 :demand-coverage 120 :id other-scenario-id       :label nil       :name "S4"      :project-id project-id :changeset "[]"}]]])
 
 (defn test-config
   ([]
@@ -82,6 +82,7 @@
 (deftest list-scenarios-order
   (test-system/with-system (test-config fixture-with-scenarios)
     (let [store        (:planwise.component/scenarios system)
+          _            (scenarios/db-update-scenarios-label! (scenarios/get-db store) {:project-id project-id})
           scenarios    (scenarios/list-scenarios store project-id)
           scenario-ids (map :id scenarios)]
       (is (= (take 3 scenario-ids) [initial-scenario-id best-scenario-id optimal-scenario-id]))

--- a/test/planwise/component/scenarios_test.clj
+++ b/test/planwise/component/scenarios_test.clj
@@ -7,7 +7,7 @@
             [planwise.util.collections :refer [find-by]]
             [clj-time.core :as time]
             [integrant.core :as ig]
-            [schema.core :as s]))
+            [clojure.spec.alpha :as s]))
 
 (def owner-id 10)
 (def project-id 20)
@@ -91,13 +91,13 @@
       (is (= (:label (find-by scenarios :id optimal-scenario-id)) "optimal")))))
 
 (deftest valid-changeset
-  (let [t #(is (nil? (s/check model/ChangeSet %)))]
-    (t [])
-    (t [{:action "create-site" :site-id "new.1" :investment 10000 :capacity 50}])))
+  (are [x] (s/valid? ::model/change-set x)
+    []
+    [{:action "create-site" :site-id "new.1" :investment 10000 :capacity 50}]))
 
 (deftest invalid-changeset
-  (let [t #(is (some? (s/check model/ChangeSet %)))]
-    (t [{:action "unknown-action" :site-id "new.1" :investment 10000 :capacity 50}])
-    (t [{:action "create-site" :site-id "new.1" :investment nil :capacity nil}])
-    (t [{:action "create-site" :site-id "new.1" :investment "" :capacity ""}])
-    (t [{:action "create-site" :site-id "new.1"}])))
+  (are [x] (not (s/valid? ::model/change-set x))
+    [{:action "unknown-action" :site-id "new.1" :investment 10000 :capacity 50}]
+    [{:action "create-site" :site-id "new.1" :investment nil :capacity nil}]
+    [{:action "create-site" :site-id "new.1" :investment "" :capacity ""}]
+    [{:action "create-site" :site-id "new.1"}]))


### PR DESCRIPTION
Fix #269 

Base implementation for scenarios.
It validates the schema of the serialized changeset.
A `label` attribute is added to signal the initial, best, optimal scenarios.
The computation is performed by db directly and the result is stored for later use.
`update-scenario-demand-coverage` is an auxiliary function that will be used once the deferred computation of the demand coverage is done.

Probably the project will have a total demand in order to compute % increases from a given scenario w.r.t initial one.