### PR TITLE
Render upload-file input when opening dialog

### DIFF
--- a/resources/sass/site2.scss
+++ b/resources/sass/site2.scss
@@ -247,6 +247,11 @@ form.vertical, .fields-vertical {
   }
 }
 
+.file-input{
+  color: transparent;
+  width: 100px;
+}
+
 .dataset-list {
   .card-item {
     height: 120px;

--- a/src/planwise/client/datasets2/components/new_dataset.cljs
+++ b/src/planwise/client/datasets2/components/new_dataset.cljs
@@ -41,13 +41,12 @@
                                                 :name (-> % .-target .-value)])}]
         [:label.file-input-wrapper
          [:div "Import sites from CSV"]
-         (when (= @view-state open?)
-           [:input {:id "file-upload"
-                    :type "file"
-                    :class "file-input"
-                    :value ""
-                    :on-change  #(rf/dispatch [:datasets2/new-dataset-update
-                                               :js-file (-> (.-currentTarget %) .-files (aget 0))])}])
+         [:input {:id "file-upload"
+                  :type "file"
+                  :class "file-input"
+                  :value ""
+                  :on-change  #(rf/dispatch [:datasets2/new-dataset-update
+                                             :js-file (-> (.-currentTarget %) .-files (aget 0))])}]
          (when (some? @js-file)
            [:span (.-name @js-file)])]
         [:a {:href (routes/download-sample)

--- a/src/planwise/client/datasets2/components/new_dataset.cljs
+++ b/src/planwise/client/datasets2/components/new_dataset.cljs
@@ -41,10 +41,11 @@
                                                 :name (-> % .-target .-value)])}]
         [:label.file-input-wrapper
          [:div "Import sites from CSV"]
-         [:input {:id "file-upload"
-                  :type "file"
-                  :on-change  #(rf/dispatch [:datasets2/new-dataset-update
-                                             :js-file (-> (.-currentTarget %) .-files (aget 0))])}]]
+         (when (= @view-state open?)
+           [:input {:id "file-upload"
+                    :type "file"
+                    :on-change  #(rf/dispatch [:datasets2/new-dataset-update
+                                               :js-file (-> (.-currentTarget %) .-files (aget 0))])}])]
         [:a {:href (routes/download-sample)
              :data-trigger "false"} "Download samples sites"]
         [m/Select {:label "Coverage algorithm"

--- a/src/planwise/client/datasets2/components/new_dataset.cljs
+++ b/src/planwise/client/datasets2/components/new_dataset.cljs
@@ -44,8 +44,12 @@
          (when (= @view-state open?)
            [:input {:id "file-upload"
                     :type "file"
+                    :value ""
                     :on-change  #(rf/dispatch [:datasets2/new-dataset-update
-                                               :js-file (-> (.-currentTarget %) .-files (aget 0))])}])]
+                                               :js-file (-> (.-currentTarget %) .-files (aget 0))])}])
+           (when (some? @js-file)
+              ;(println (-> @js-file .getName))
+              [:span (.-name @js-file)])]
         [:a {:href (routes/download-sample)
              :data-trigger "false"} "Download samples sites"]
         [m/Select {:label "Coverage algorithm"

--- a/src/planwise/client/datasets2/components/new_dataset.cljs
+++ b/src/planwise/client/datasets2/components/new_dataset.cljs
@@ -44,12 +44,12 @@
          (when (= @view-state open?)
            [:input {:id "file-upload"
                     :type "file"
+                    :class "file-input"
                     :value ""
                     :on-change  #(rf/dispatch [:datasets2/new-dataset-update
                                                :js-file (-> (.-currentTarget %) .-files (aget 0))])}])
-           (when (some? @js-file)
-              ;(println (-> @js-file .getName))
-              [:span (.-name @js-file)])]
+         (when (some? @js-file)
+           [:span (.-name @js-file)])]
         [:a {:href (routes/download-sample)
              :data-trigger "false"} "Download samples sites"]
         [m/Select {:label "Coverage algorithm"


### PR DESCRIPTION
Fixes #330 
Input type="file" mismatched file-name besides upload button. After creating a dataset, when trying to create another instead of showing "No chosen file" it was shown the file-name of the last .csv file uploaded.