### PR TITLE
Disable dropdown if no datasets

### DIFF
--- a/src/planwise/client/datasets2/components/dropdown.cljs
+++ b/src/planwise/client/datasets2/components/dropdown.cljs
@@ -28,7 +28,7 @@
   [{:keys [label value on-change disabled?]}]
   (let [list      (subscribe [:datasets2/list])
         options   (subscribe [:datasets2/dropdown-options])
-        component (if disabled?
+        component (if (or disabled? (empty? @options))
                     disabled-input-component
                     datasets-select-component)]
     (when (asdf/should-reload? @list)


### PR DESCRIPTION
Fix #385 