### PR TITLE
Fix-Common text field

### DIFF
--- a/src/planwise/client/components/common2.cljs
+++ b/src/planwise/client/components/common2.cljs
@@ -52,9 +52,8 @@
          [:input.mdc-text-field__input (merge props {:id id
                                                      :on-focus #(reset! focus true)
                                                      :on-blur  #(do
-                                                                  (when reset-local-value (reset-local-value))
-                                                                  (on-change)
-                                                                  (reset! focus false))
+                                                                  (reset! focus false)
+                                                                  (when reset-local-value (reset-local-value)))
                                                      :on-change on-change}
                                               (when @focus
                                                 {:placeholder nil}))]
@@ -67,7 +66,7 @@
   [{:keys [value sub-type] :as props-input}]
   (let [local (r/atom (str value))
         [valid-fn parse-fn] (set-format sub-type)]
-    (fn [{:keys [on-change focus-extra-class] :as props-input}]
+    (fn [{:keys [value on-change focus-extra-class] :as props-input}]
       (let [props (dissoc props-input :sub-type :field)
             necessary? (not= focus-extra-class " invalid-input")
             wrong-input (not= (valid-fn @local) @local)]
@@ -76,5 +75,5 @@
                            :on-change #(do
                                          (reset! local (-> % .-target .-value str))
                                          (on-change (parse-fn (valid-fn @local))))
-                           :reset-local-value #(reset! local (str (valid-fn @local)))
+                           :reset-local-value #(reset! local (str value))
                            :value @local)]))))

--- a/src/planwise/client/components/common2.cljs
+++ b/src/planwise/client/components/common2.cljs
@@ -76,4 +76,4 @@
                                          (reset! local (-> % .-target .-value str))
                                          (on-change (parse-fn (valid-fn @local))))
                            :reset-local-value #(reset! local (str value))
-                           :value @local)]))))
+                           :value (or @local ""))]))))

--- a/src/planwise/client/components/common2.cljs
+++ b/src/planwise/client/components/common2.cljs
@@ -34,40 +34,44 @@
    [:p "Loading..."]])
 
 (defn- set-format
-  [field type]
+  [type]
   (let [not-nan #(when-not (js/isNaN %) %)
         type (or type :integer)]
-    (cond (#{[:numeric :integer]} [field type]) [(fn [e] (re-find #"\d+" e)) (comp not-nan js/parseInt)]
-          (#{[:numeric :percentage]} [field type]) [(fn [e] (re-find #"(?u)100|\d{0,2}\.\d+|\d{0,2}\.|\d{0,2}" e)) (comp not-nan js/parseFloat)]
-          (#{[:numeric :float]} [field type]) [(fn [e] (re-find #"\d+\.\d+|\d+\.|\d+" e)) (comp not-nan js/parseFloat)]
+    (cond (#{:integer} type) [(fn [e] (println "look res" (re-find #"\d+" e)) (re-find #"\d+" e)) (comp not-nan js/parseInt)]
+          (#{:percentage} type) [(fn [e] (re-find #"(?u)100|\d{0,2}\.\d+|\d{0,2}\.|\d{0,2}" e)) (comp not-nan js/parseFloat)]
+          (#{:float} type) [(fn [e] (re-find #"\d+\.\d+|\d+\.|\d+" e)) (comp not-nan js/parseFloat)]
           :else [identity identity])))
 
 (defn text-field
-  ([{:keys [value field type] :as props-input}]
-   (let [focus (r/atom false)
-         id    (str (random-uuid))
-         local (r/atom value)
-         [valid-fn parse-fn] (apply set-format [field type])]
-     (fn [{:keys [label value focus-extra-class on-change] :as props-input}]
-       (let [props (dissoc props-input :label :focus-extra-class :type :field)
-             necessary? (not= focus-extra-class " invalid-input")
-             wrong-input (not= (valid-fn @local) @local)]
-         [:div.mdc-text-field.mdc-text-field--upgraded {:class (when @focus
-                                                                 (str "mdc-text-field--focused"
-                                                                      focus-extra-class
-                                                                      (when (and wrong-input necessary?) " invalid-input")))}
-          [:input.mdc-text-field__input (merge props {:id id
-                                                      :type "text"
-                                                      :on-change #(when @focus (reset! local (-> % .-target .-value)))
-                                                      :value @local
-                                                      :on-focus  #(reset! focus true)
-                                                      :on-blur #(do
-                                                                  (reset! focus false)
-                                                                  (on-change (parse-fn (valid-fn @local)))
-                                                                  (reset! local (valid-fn @local)))})]
-          [:label.mdc-floating-label {:for id
-                                      :class (when (or (not (blank? (str value))) @focus) "mdc-floating-label--float-above")}
-           label]
-          [:div.mdc-line-ripple {:class (when @focus "mdc-line-ripple--active")}]])))))
+  [props-input]
+  (let [focus (r/atom false)
+        id    (str (random-uuid))]
+    (fn [{:keys [label value focus-extra-class on-change] :as props-input}]
+      (println "value" value)
+      (let [props (dissoc props-input :label :focus-extra-class :on-change)]
+        [:div.mdc-text-field.mdc-text-field--upgraded {:class (when @focus (str "mdc-text-field--focused" focus-extra-class))}
+         [:input.mdc-text-field__input (merge props {:id id
+                                                     :on-focus #(reset! focus true)
+                                                     :on-blur  #(reset! focus false)
+                                                     :on-change on-change}
+                                              (when @focus
+                                                {:placeholder nil}))]
+         [:label.mdc-floating-label {:for id
+                                     :class (when (or (not (blank? (str value))) @focus) "mdc-floating-label--float-above")}
+          label]
+         [:div.mdc-line-ripple {:class (when @focus "mdc-line-ripple--active")}]]))))
 
-
+(defn numeric-text-field
+  [{:keys [value sub-type] :as props-input}]
+  (let [local (r/atom (str value))
+        [valid-fn parse-fn] (set-format sub-type)]
+    (fn [{:keys [on-change focus-extra-class] :as props-input}]
+      (let [props (dissoc props-input :sub-type :field)
+            necessary? (not= focus-extra-class " invalid-input")
+            wrong-input (not= (valid-fn @local) @local)]
+        [text-field (assoc props :focus-extra-class (if (and wrong-input necessary?) " invalid-input" "")
+                           :type "text"
+                           :on-change #(do
+                                         (on-change (parse-fn (valid-fn @local)))
+                                         (reset! local (-> % .-target .-value)))
+                           :value @local)]))))

--- a/src/planwise/client/dialog.cljs
+++ b/src/planwise/client/dialog.cljs
@@ -3,7 +3,7 @@
             [planwise.client.utils :as utils]))
 
 (defn dialog
-  [{:keys [open? title content accept-fn cancel-fn delete-fn]}]
+  [{:keys [open? title content accept-fn cancel-fn delete-fn disable-accept-button]}]
   [m/Dialog {:open open?
              :on-accept accept-fn
              :on-close cancel-fn}
@@ -16,4 +16,5 @@
     [m/DialogFooter
      (when (some? delete-fn) [m/Button {:on-click delete-fn} "Delete"])
      (when (some? cancel-fn) [m/DialogFooterButton {:cancel true} "Cancel"])
-     (when (some? accept-fn) [m/DialogFooterButton {:accept true} "OK"])]]])
+     (when (some? accept-fn) [m/DialogFooterButton {:accept true
+                                                    :disabled disable-accept-button} "OK"])]]])

--- a/src/planwise/client/scenarios/edit.cljs
+++ b/src/planwise/client/scenarios/edit.cljs
@@ -31,13 +31,13 @@
   [:div
    [:h2 "Investment"]
    [common2/text-field {:type "number"
-                        :on-change  #(dispatch [:scenarios/save-key [:changeset-dialog :investment] (-> % .-target .-value js/parseInt)])
+                        :on-change  #(dispatch [:scenarios/save-key [:changeset-dialog :investment] %])
                         :focus-extra-class (when (< available-budget investment) " invalid-input")
                         :value (or investment "")}]
 
    [:h2 "Capacity"]
    [common2/text-field {:type "number"
-                        :on-change  #(dispatch [:scenarios/save-key  [:changeset-dialog :capacity] (-> % .-target .-value js/parseInt)])
+                        :on-change  #(dispatch [:scenarios/save-key  [:changeset-dialog :capacity] %])
                         :value (or capacity "")}]])
 (defn changeset-dialog
   [scenario budget]

--- a/src/planwise/client/scenarios/edit.cljs
+++ b/src/planwise/client/scenarios/edit.cljs
@@ -30,15 +30,15 @@
   [{:keys [investment available-budget capacity]}]
   [:div
    [:h2 "Investment"]
-   [common2/text-field {:type "number"
-                        :on-change  #(dispatch [:scenarios/save-key [:changeset-dialog :investment] %])
-                        :focus-extra-class (when (< available-budget investment) " invalid-input")
-                        :value (or investment "")}]
+   [common2/numeric-text-field {:type "number"
+                                :on-change #(dispatch [:scenarios/save-key [:changeset-dialog :investment] %])
+                                :focus-extra-class (when (< available-budget investment) " invalid-input")
+                                :value (or investment "")}]
 
    [:h2 "Capacity"]
-   [common2/text-field {:type "number"
-                        :on-change  #(dispatch [:scenarios/save-key  [:changeset-dialog :capacity] %])
-                        :value (or capacity "")}]])
+   [common2/numeric-text-field {:type "number"
+                                :on-change  #(dispatch [:scenarios/save-key  [:changeset-dialog :capacity] %])
+                                :value (or capacity "")}]])
 (defn changeset-dialog
   [scenario budget]
   (let [provider       (subscribe [:scenarios/changeset-dialog])

--- a/src/planwise/client/scenarios/edit.cljs
+++ b/src/planwise/client/scenarios/edit.cljs
@@ -46,6 +46,7 @@
         provider-index (subscribe [:scenarios/changeset-index])]
     (fn [scenario budget]
       (dialog {:open? (= @view-state :changeset-dialog)
+               :disable-accept-button (or (nil? (:capacity @provider)) (nil? (:investment @provider)))
                :title "Edit Provider"
                :content (changeset-dialog-content (assoc @provider :available-budget (- budget (:investment scenario))))
                :delete-fn #(dispatch [:scenarios/delete-provider @provider-index])


### PR DESCRIPTION
Replacing all inputs in #475 created inconsistent forms.
To achieve same purpose: a previous version of "text-field" was recovered and create "numeric-text-field" so as to change only "number" type inputs
