### PR TITLE
Fix showing changeset

### DIFF
--- a/src/planwise/client/scenarios/db.cljs
+++ b/src/planwise/client/scenarios/db.cljs
@@ -15,9 +15,10 @@
 (defmethod new-action :create
   [props]
   {:action     "create-provider"
+   :name       (:name props)
    :investment 0
    :capacity   0
-   :location   props
+   :location   (:location props)
    :id         (str (random-uuid))})
 
 (defmethod new-action :upgrade
@@ -35,9 +36,9 @@
    :id         (:id props)})
 
 (defn new-provider-from-change
-  [change index]
+  [change]
   {:id             (:id change)
-   :name           (str "New Provider " index)
+   :name           (:name change)
    :location       (:location change)
    :matches-filter true
    :change         change})

--- a/src/planwise/client/scenarios/handlers.cljs
+++ b/src/planwise/client/scenarios/handlers.cljs
@@ -178,10 +178,14 @@
  (fn [{:keys [db]} [_]]
    (let [current-scenario  (get-in db [:current-scenario])
          updated-provider  (get-in db [:changeset-dialog])
+         new-change?       (empty? (filter #(= (:id %) (:id updated-provider)) (:changeset current-scenario)))
          updated-scenario  (update current-scenario
                                    :changeset
-                                   (fn [c] (conj (utils/remove-by-id c (:id updated-provider))
-                                                 (:change updated-provider))))]
+                                   (fn [c]
+                                    (if new-change?
+                                     (conj (vec c) (:change updated-provider))
+                                     (utils/replace-by-id c (:change updated-provider))
+                                     )))]
      {:api  (assoc (api/update-scenario (:id current-scenario) updated-scenario)
                    :on-success [:scenarios/update-demand-information])
       :db   (-> db

--- a/src/planwise/client/scenarios/handlers.cljs
+++ b/src/planwise/client/scenarios/handlers.cljs
@@ -142,20 +142,27 @@
                 (assoc-in [:current-scenario :name] name)
                 (assoc-in [:view-state] :current-scenario))})))
 
+(defn next-new-provider
+  [changeset]
+  (let [new-providers (filter #(= (:action %) "create-provider") changeset)]
+    (if (empty? new-providers)
+        "New provider 0"
+        (let [vals (mapv (fn [p] (->> (:name p) (re-find #"\d+") js/parseInt)) new-providers)]
+         (str "New provider " (inc (apply max vals)))))))
+
 (rf/reg-event-fx
  :scenarios/create-provider
  in-scenarios
- (fn [{:keys [db]} [_ props]]
+ (fn [{:keys [db]} [_ location]]
    (let [{:keys [current-scenario]} db
-         new-action   (db/new-action props :create)
-         number-of-changes (count (:changeset current-scenario))
-         index        (if (pos? number-of-changes) (dec number-of-changes) 0)
+         new-action   (db/new-action {:location location
+                                      :name (next-new-provider (:changeset current-scenario))} :create)
          updated-scenario (dissoc current-scenario
                                   :suggested-locations :computing-best-locations)]
      {:api  (assoc (api/update-scenario (:id current-scenario) updated-scenario)
                    :on-success [:scenarios/update-demand-information])
       :db   (assoc  db :current-scenario updated-scenario)
-      :dispatch [:scenarios/open-changeset-dialog (db/new-provider-from-change new-action index)]})))
+      :dispatch [:scenarios/open-changeset-dialog (db/new-provider-from-change new-action)]})))
 
 (rf/reg-event-db
  :scenarios/open-changeset-dialog

--- a/src/planwise/client/scenarios/handlers.cljs
+++ b/src/planwise/client/scenarios/handlers.cljs
@@ -142,13 +142,13 @@
                 (assoc-in [:current-scenario :name] name)
                 (assoc-in [:view-state] :current-scenario))})))
 
-(defn next-new-provider
+(defn new-provider-name
   [changeset]
   (let [new-providers (filter #(= (:action %) "create-provider") changeset)]
     (if (empty? new-providers)
-        "New provider 0"
-        (let [vals (mapv (fn [p] (->> (:name p) (re-find #"\d+") js/parseInt)) new-providers)]
-         (str "New provider " (inc (apply max vals)))))))
+      "New provider 0"
+      (let [vals (mapv (fn [p] (->> (:name p) (re-find #"\d+") js/parseInt)) new-providers)]
+        (str "New provider " (inc (apply max vals)))))))
 
 (rf/reg-event-fx
  :scenarios/create-provider
@@ -156,7 +156,7 @@
  (fn [{:keys [db]} [_ location]]
    (let [{:keys [current-scenario]} db
          new-action   (db/new-action {:location location
-                                      :name (next-new-provider (:changeset current-scenario))} :create)
+                                      :name (new-provider-name (:changeset current-scenario))} :create)
          updated-scenario (dissoc current-scenario
                                   :suggested-locations :computing-best-locations)]
      {:api  (assoc (api/update-scenario (:id current-scenario) updated-scenario)
@@ -182,10 +182,9 @@
          updated-scenario  (update current-scenario
                                    :changeset
                                    (fn [c]
-                                    (if new-change?
-                                     (conj (vec c) (:change updated-provider))
-                                     (utils/replace-by-id c (:change updated-provider))
-                                     )))]
+                                     (if new-change?
+                                       (conj (vec c) (:change updated-provider))
+                                       (utils/replace-by-id c (:change updated-provider)))))]
      {:api  (assoc (api/update-scenario (:id current-scenario) updated-scenario)
                    :on-success [:scenarios/update-demand-information])
       :db   (-> db

--- a/src/planwise/client/scenarios/handlers.cljs
+++ b/src/planwise/client/scenarios/handlers.cljs
@@ -147,7 +147,7 @@
   (let [new-providers (filter #(= (:action %) "create-provider") changeset)]
     (if (empty? new-providers)
       "New provider 0"
-      (let [vals (mapv (fn [p] (->> (:name p) (re-find #"\d+") js/parseInt)) new-providers)]
+      (let [vals (mapv (fn [p] (->> (:name p) (re-find #"\d+") int)) new-providers)]
         (str "New provider " (inc (apply max vals)))))))
 
 (rf/reg-event-fx
@@ -178,7 +178,7 @@
  (fn [{:keys [db]} [_]]
    (let [current-scenario  (get-in db [:current-scenario])
          updated-provider  (get-in db [:changeset-dialog])
-         new-change?       (empty? (filter #(= (:id %) (:id updated-provider)) (:changeset current-scenario)))
+         new-change?       (nil? (utils/find-by-id (:changeset current-scenario) (:id updated-provider)))
          updated-scenario  (update current-scenario
                                    :changeset
                                    (fn [c]

--- a/src/planwise/client/scenarios/subs.cljs
+++ b/src/planwise/client/scenarios/subs.cljs
@@ -80,7 +80,7 @@
 (defn apply-change
   [providers [index change]]
   (if (= (:action change) "create-provider")
-    (conj providers (db/new-provider-from-change change index))
+    (conj providers (db/new-provider-from-change change))
     (utils/update-by-id providers (:id change) assoc :change change)))
 
 (rf/reg-sub
@@ -95,6 +95,9 @@
       (reduce apply-change providers' (map-indexed vector changeset))))))
 
 (rf/reg-sub
- :scenarios/providers-from-changeset :<- [:scenarios/all-providers]
- (fn [all-providers [_]]
-   (filter #(some? (:change %)) all-providers)))
+ :scenarios/providers-from-changeset
+ (fn [_]
+   [(rf/subscribe [:scenarios/all-providers])
+    (rf/subscribe [:scenarios/current-scenario])])
+ (fn [[all-providers {:keys [changeset]}] _]
+   (map #(utils/find-by-id all-providers (:id %)) changeset)))

--- a/src/planwise/model/scenarios.clj
+++ b/src/planwise/model/scenarios.clj
@@ -6,12 +6,13 @@
 (s/def :planwise.scenarios.new-change/id string?)
 (s/def :planwise.scenarios.change/id number?)
 (s/def ::location map?)
+(s/def ::name string?)
 
 (s/def ::base-change
   (s/keys :req-un [::investment ::capacity]))
 
 (s/def ::create-provider
-  (s/keys :req-un [:planwise.scenarios.new-change/id ::location]))
+  (s/keys :req-un [:planwise.scenarios.new-change/id ::location ::name]))
 
 (s/def ::upgrade-provider
   (s/keys :req-un [:planwise.scenarios.change/id]))

--- a/test/planwise/client/scenarios_test.cljs
+++ b/test/planwise/client/scenarios_test.cljs
@@ -4,6 +4,7 @@
 
 (deftest new-provider-from-change-test
   (let [change {:id       "foo"
+                :name           "New Provider 1"
                 :action   "create-provider"
                 :location {:lat 0 :lon 0}}]
     (is (= {:id             "foo"

--- a/test/planwise/component/scenarios_test.clj
+++ b/test/planwise/component/scenarios_test.clj
@@ -80,8 +80,8 @@
   (test-system/with-system (test-config)
     (let [store       (:planwise.component/scenarios system)
           projects2   (:planwise.component/projects2 system)
-          first-action {:action "create-provider" :id "new.1" :investment 10000 :capacity 50 :location {:lat 0 :lon 0}}
-          second-action {:action "create-provider" :id "new.2" :investment 5000 :capacity 20 :location {:lat 0 :lon 0}}
+          first-action {:action "create-provider" :name "New provider 0" :id "new.1" :investment 10000 :capacity 50 :location {:lat 0 :lon 0}}
+          second-action {:action "create-provider" :name "New provider 1" :id "new.2" :investment 5000 :capacity 20 :location {:lat 0 :lon 0}}
           props       {:name "Foo" :changeset [first-action second-action]}
           project     (projects2/get-project projects2 project-id)
           scenario-id (:id (scenarios/create-scenario store project props))
@@ -108,9 +108,9 @@
 (deftest valid-changeset
   (are [x] (s/valid? ::model/change-set x)
     []
-    [{:action "create-provider" :id "new.1" :investment 1000 :capacity 50 :location {:lat 0 :lon 0}}]
-    [{:action "create-provider" :id "new.2" :investment 10000 :capacity 50 :location {:lat 0 :lon 0}}]
-    [{:action "create-provider" :id "new.3" :investment 10000 :capacity 50 :location {:lat 0 :lon 0}}
+    [{:action "create-provider" :name "New provider 1" :id "new.1" :investment 1000 :capacity 50 :location {:lat 0 :lon 0}}]
+    [{:action "create-provider" :name "New provider 2" :id "new.2" :investment 10000 :capacity 50 :location {:lat 0 :lon 0}}]
+    [{:action "create-provider" :name "New provider 3" :id "new.3" :investment 10000 :capacity 50 :location {:lat 0 :lon 0}}
      {:action "upgrade-provider" :id 1 :investment 10000 :capacity 50}]))
 
 (deftest invalid-changeset


### PR DESCRIPTION
New providers name are created once the action is created, does not depend on the all-providers subscription.
New providers are added at the end of changeset, and edited changes do not modify the order of changeset.
Subscription for showing actions in side-panel have same order as changeset.