### PR TITLE
Fix numerical inputs and fix editable action

### DIFF
--- a/src/planwise/client/components/common2.cljs
+++ b/src/planwise/client/components/common2.cljs
@@ -87,14 +87,16 @@
                              {:id    (str (random-uuid))
                               :focus focus
                               :focus-extra-class (when wrong-input " invalid-input")})
-            on-change       (:on-change props)
+            on-change-fn    (:on-change props)
             global-value    (:value props)
             props           (merge
                              (dissoc props extra-keys)
                              {:on-change #(do
                                             (reset! local-value (-> % .-target .-value str))
-                                            (on-change (parse-fn (validate-fn @local-value))))
+                                            (on-change-fn (parse-fn (validate-fn @local-value))))
                               :value (if @focus @local-value global-value)})]
-        (when-not (or @focus (= @local-value global-value))
-          (reset! local-value (str global-value)))
+        (let [changed-global-value? (and (not @focus)
+                                         (not= @local-value global-value))]
+          (when changed-global-value?
+            (reset! local-value (str global-value))))
         [mdc-input-field props component-props]))))

--- a/src/planwise/client/components/common2.cljs
+++ b/src/planwise/client/components/common2.cljs
@@ -34,60 +34,67 @@
   [ui/fixed-width (nav-params)
    [:p "Loading..."]])
 
+(defn mdc-input-field
+  [props component-props]
+  (let [{:keys [id focus focus-extra-class label]} component-props]
+    [:div.mdc-text-field.mdc-text-field--upgraded {:class (cond
+                                                            (:read-only props) focus-extra-class
+                                                            @focus (str "mdc-text-field--focused" focus-extra-class))}
+     [:input.mdc-text-field__input (merge props {:id id
+                                                 :on-focus #(reset! focus true)
+                                                 :on-blur  #(reset! focus false)}
+                                          (when @focus
+                                            {:placeholder nil}))]
+     [:label.mdc-floating-label {:for id
+                                 :class (when (or (not (blank? (str (:value props))))
+                                                  @focus) "mdc-floating-label--float-above")}
+      label]
+     [:div.mdc-line-ripple {:class (when @focus "mdc-line-ripple--active")}]]))
+
+(def extra-keys
+  [:label :focus-extra-class :sub-type :invalid-input :type])
+
 (defn text-field
-  [props-input]
+  [props]
   (let [focus (r/atom false)
         id    (str (random-uuid))]
-    (fn [{:keys [label value focus-extra-class on-change] :as props-input}]
-      (let [props (dissoc props-input :label :focus-extra-class :on-change)]
-        [:div.mdc-text-field.mdc-text-field--upgraded {:class (cond (:read-only props) focus-extra-class
-                                                                    @focus (str "mdc-text-field--focused" focus-extra-class)
-                                                                    :else nil)}
-         [:input.mdc-text-field__input (merge props {:id id
-                                                     :on-focus #(reset! focus true)
-                                                     :on-blur  #(reset! focus false)
-                                                     :on-change on-change}
-                                              (when @focus
-                                                {:placeholder nil}))]
-         [:label.mdc-floating-label {:for id
-                                     :class (when (or (not (blank? (str value))) @focus) "mdc-floating-label--float-above")}
-          label]
-         [:div.mdc-line-ripple {:class (when @focus "mdc-line-ripple--active")}]]))))
+    (fn [props]
+      (let [component-props (assoc (select-keys props extra-keys)
+                                   :id id
+                                   :focus focus)
+            props           (dissoc props extra-keys)]
+        [mdc-input-field props component-props]))))
 
-(defn- set-format
+(defn- set-numeric-format
   [type]
   (let [not-nan #(when-not (js/isNaN %) %)
         type (or type :integer)]
     (case type
-      :integer [(fn [e] (re-find #"\d+" e)) (comp not-nan js/parseInt)]
+      :integer    [(fn [e] (re-find #"\d+" e))                                    (comp not-nan js/parseInt)]
       :percentage [(fn [e] (re-find #"(?u)100|\d{0,2}\.\d+|\d{0,2}\.|\d{0,2}" e)) (comp not-nan js/parseFloat)]
-      :float [(fn [e] (re-find #"\d+\.\d+|\d+\.|\d+" e)) (comp not-nan js/parseFloat)]
+      :float      [(fn [e] (re-find #"\d+\.\d+|\d+\.|\d+" e))                     (comp not-nan js/parseFloat)]
       [identity identity])))
 
 (defn numeric-field
-  [props-input]
-  (let [focus       (r/atom false)
-        local-value (r/atom (str (:value props-input)))
-        id          (str (random-uuid))
-        [valid-fn parse-fn] (set-format (:sub-type props-input))]
-    (fn [{:keys [label not-valid? value on-change] :as props-input}]
-      (let [props             (dissoc props-input :label :not-valid?)
-            wrong-input       (not= (valid-fn @local-value) @local-value)
-            focus-extra-class (when (or wrong-input not-valid?) " invalid-input")]
-        (when-not (or @focus (= @local-value value)) (reset! local-value (str value)))
-        [:div.mdc-text-field.mdc-text-field--upgraded {:class (cond (:read-only props) focus-extra-class
-                                                                    @focus (str "mdc-text-field--focused" focus-extra-class)
-                                                                    :else nil)}
-         [:input.mdc-text-field__input (merge props {:id       id
-                                                     :on-focus #(reset! focus true)
-                                                     :on-blur  #(reset! focus false)
-                                                     :on-change #(do
-                                                                   (reset! local-value (-> % .-target .-value str))
-                                                                   (on-change (parse-fn (valid-fn @local-value))))
-                                                     :value (if @focus @local-value value)}
-                                              (when @focus
-                                                {:placeholder nil}))]
-         [:label.mdc-floating-label {:for id
-                                     :class (when (or (not (blank? (str value))) @focus) "mdc-floating-label--float-above")}
-          label]
-         [:div.mdc-line-ripple {:class (when @focus "mdc-line-ripple--active")}]]))))
+  [props]
+  (let [focus                  (r/atom false)
+        local-value            (r/atom (str (:value props)))
+        [validate-fn parse-fn] (set-numeric-format (:sub-type props))]
+    (fn [props]
+      (let [wrong-input     (or (not= (validate-fn @local-value) @local-value) (:invalid-input props))
+            component-props (merge
+                             (select-keys props extra-keys)
+                             {:id    (str (random-uuid))
+                              :focus focus
+                              :focus-extra-class (when wrong-input " invalid-input")})
+            on-change       (:on-change props)
+            global-value    (:value props)
+            props           (merge
+                             (dissoc props extra-keys)
+                             {:on-change #(do
+                                            (reset! local-value (-> % .-target .-value str))
+                                            (on-change (parse-fn (validate-fn @local-value))))
+                              :value (if @focus @local-value global-value)})]
+        (when-not (or @focus (= @local-value global-value))
+          (reset! local-value (str global-value)))
+        [mdc-input-field props component-props]))))

--- a/src/planwise/client/components/common2.cljs
+++ b/src/planwise/client/components/common2.cljs
@@ -62,7 +62,7 @@
       (let [component-props (assoc (select-keys props extra-keys)
                                    :id id
                                    :focus focus)
-            props           (dissoc props extra-keys)]
+            props           (apply dissoc props extra-keys)]
         [mdc-input-field props component-props]))))
 
 (defn- set-numeric-format
@@ -88,9 +88,9 @@
                               :focus focus
                               :focus-extra-class (when wrong-input " invalid-input")})
             on-change-fn    (:on-change props)
-            global-value    (:value props)
+            global-value    (str (:value props))
             props           (merge
-                             (dissoc props extra-keys)
+                             (apply dissoc props extra-keys)
                              {:on-change #(do
                                             (reset! local-value (-> % .-target .-value str))
                                             (on-change-fn (parse-fn (validate-fn @local-value))))

--- a/src/planwise/client/projects2/components/settings.cljs
+++ b/src/planwise/client/projects2/components/settings.cljs
@@ -43,7 +43,7 @@
                        :on-change (comp change-fn (fn [e] (-> e .-target .-value)))
                        :value     value})]
      (case type
-       "number" [common2/numeric-text-field (assoc props :on-change change-fn)]
+       "number" [common2/numeric-field (assoc props :on-change change-fn)]
        [common2/text-field props]))))
 
 (defn- project-start-button

--- a/src/planwise/client/scenarios/edit.cljs
+++ b/src/planwise/client/scenarios/edit.cljs
@@ -53,10 +53,10 @@
 (defn configured-costs?
   [props]
   (case (get-in props [:change :action])
-    "increase-provider" (not (empty? (:increasing-costs props)))
+    "increase-provider" (seq (:increasing-costs props))
     "upgrade-provider"  (and (pos? (:upgrade-budget props))
-                             (not (empty? (:increasing-costs props))))
-    (some? (:building-costs props))))
+                             (seq (:increasing-costs props)))
+    (seq (:building-costs props))))
 
 (defn changeset-dialog-content
   [{:keys [name initial-capacity capacity required-capacity free-capacity available-budget change] :as provider} props]
@@ -75,7 +75,7 @@
                              :value initial-capacity}])
       [common2/numeric-field {:label (if increase? "Extra capacity" "Capacity")
                               :on-change  #(dispatch [:scenarios/save-key  [:changeset-dialog :change :capacity] %])
-                              :value (or (:capacity change) "")}]
+                              :value (:capacity change)}]
       (when-not new?
         (let [extra-capacity          (:capacity change)
               total-required-capacity (if idle? (- capacity free-capacity) (+ capacity required-capacity))
@@ -97,7 +97,7 @@
                                 :sub-type      :float
                                 :on-change     #(dispatch [:scenarios/save-key [:changeset-dialog :change :investment] %])
                                 :invalid-input (< available-budget (:investment change))
-                                :value         (or (:investment change) "")}]
+                                :value         (:investment change)}]
         [common2/numeric-field {:label         "Available budget"
                                 :sub-type      :float
                                 :read-only     true

--- a/src/planwise/client/scenarios/edit.cljs
+++ b/src/planwise/client/scenarios/edit.cljs
@@ -65,10 +65,10 @@
         [common2/text-field {:label "Original capacity"
                              :read-only true
                              :value initial-capacity}])
-      [common2/numeric-text-field {:type "number"
-                                   :label (if increase? "Extra capacity" "Capacity")
-                                   :on-change  #(dispatch [:scenarios/save-key  [:changeset-dialog :change :capacity] %])
-                                   :value (or (:capacity change) "")}]
+      [common2/numeric-field {:type "number"
+                              :label (if increase? "Extra capacity" "Capacity")
+                              :on-change  #(dispatch [:scenarios/save-key  [:changeset-dialog :change :capacity] %])
+                              :value (or (:capacity change) "")}]
       (when-not new?
         (let [extra-capacity          (:capacity change)
               total-required-capacity (if idle? (- capacity free-capacity) (+ capacity required-capacity))
@@ -88,15 +88,15 @@
                                         (some? (:building-costs props)))
            suggested-cost             (suggest-investment change props)]
        [:div
-        [common2/numeric-text-field {:type "number"
-                                     :label "Investment"
-                                     :on-change #(dispatch [:scenarios/save-key [:changeset-dialog :change :investment] %])
-                                     :not-valid? (< available-budget (:investment change))
-                                     :value (or (:investment change) "")}]
-        [common2/numeric-text-field {:label "Available budget"
-                                     :type "number"
-                                     :read-only true
-                                     :value (if (pos? remaining-budget) remaining-budget 0)}]
+        [common2/numeric-field {:type "number"
+                                :label "Investment"
+                                :on-change #(dispatch [:scenarios/save-key [:changeset-dialog :change :investment] %])
+                                :not-valid? (< available-budget (:investment change))
+                                :value (or (:investment change) "")}]
+        [common2/numeric-field {:label "Available budget"
+                                :type "number"
+                                :read-only true
+                                :value (if (pos? remaining-budget) remaining-budget 0)}]
         (when (or building-costs-for-action? (:action-cost provider))
           [:p.text-helper {:on-click #(dispatch [:scenarios/save-key [:changeset-dialog :change :investment] suggested-cost])}
            "Suggested investment according to project configuration: " suggested-cost])])]))

--- a/src/planwise/client/scenarios/edit.cljs
+++ b/src/planwise/client/scenarios/edit.cljs
@@ -88,15 +88,15 @@
                                         (some? (:building-costs props)))
            suggested-cost             (suggest-investment change props)]
        [:div
-        [common2/numeric-field {:type "number"
-                                :label "Investment"
-                                :on-change #(dispatch [:scenarios/save-key [:changeset-dialog :change :investment] %])
-                                :not-valid? (< available-budget (:investment change))
-                                :value (or (:investment change) "")}]
-        [common2/numeric-field {:label "Available budget"
-                                :type "number"
-                                :read-only true
-                                :value (if (pos? remaining-budget) remaining-budget 0)}]
+        [common2/numeric-field {:type           "number"
+                                :label         "Investment"
+                                :on-change     #(dispatch [:scenarios/save-key [:changeset-dialog :change :investment] %])
+                                :invalid-input (< available-budget (:investment change))
+                                :value         (or (:investment change) "")}]
+        [common2/numeric-field {:label         "Available budget"
+                                :type          "number"
+                                :read-only     true
+                                :value        (if (pos? remaining-budget) remaining-budget 0)}]
         (when (or building-costs-for-action? (:action-cost provider))
           [:p.text-helper {:on-click #(dispatch [:scenarios/save-key [:changeset-dialog :change :investment] suggested-cost])}
            "Suggested investment according to project configuration: " suggested-cost])])]))


### PR DESCRIPTION
Closes #503
Create general "mdc-input-field" which receives as input: props and component props. 
Props are attributes of the input element inside "mdc-input-field".
Component props are extra attributes for controlling local state of "mdc-input-field".

Besides, when editing an action:
 investment may now be float and suggested investment should not exceed remaining budget.
