### PR TITLE
Update readme when creating a test db in Docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ running `(load-sql)`.
 Running the tests require a separate scratch database.
 
 ```bash
-$ docker-compose exec db createdb planwise-test
+$ docker-compose exec db createdb planwise-test -U planwise
 ```
 
 The connection configuration is located in the environment variable


### PR DESCRIPTION
When executing the command provided in README.md to create a "planwise-test" database, the following error was shown:

`> createdb: could not connect to database template1: FATAL:  role "root" does not exist`

The command described in the README.md was missing a `-U planwise`:

> ### Testing
> 
> Running the tests require a separate scratch database.
> 
> ```bash
> $ docker-compose exec db createdb planwise-test -U planwise
> ```
