### PR TITLE
Feature/615 demand unit

### DIFF
--- a/client/src/planwise/client/projects2/components/settings.cljs
+++ b/client/src/planwise/client/projects2/components/settings.cljs
@@ -190,10 +190,13 @@
                                   :on-change #(dispatch [:projects2/save-key :source-set-id %])
                                   :disabled?  read-only}]
      [current-project-input "Consumers Unit" [:config :demographics :unit-name] "text" {:disabled read-only}]
-     [m/TextFieldHelperText {:persistent true} (str "How do you refer to the filtered population? (Eg: women)")]
+     [m/TextFieldHelperText {:persistent true} (str "How do you refer to the filtered consumers source?")]
+     [current-project-input "Demand Unit" [:config :demographics :demand-unit] "text" {:disabled read-only}]
+     [m/TextFieldHelperText {:persistent true} (str "How do you refer to the unit of your demand?")]
      [:div.percentage-input
       [current-project-input "Target" [:config :demographics :target] "number" "" "%"  {:disabled read-only :sub-type :percentage}]
-      [:p (str "of " (or (not-empty (get-in @current-project [:config :demographics :unit-name])) "population") " should be considered")]]]))
+      [:p (str "of " (or (not-empty (get-in @current-project [:config :demographics :unit-name])) "total population") " should be counted as "
+               (or (not-empty (get-in @current-project [:config :demographics :demand-unit])) "target"))]]]))
 
 (defn- current-project-step-providers
   [read-only]

--- a/client/src/planwise/client/projects2/components/settings.cljs
+++ b/client/src/planwise/client/projects2/components/settings.cljs
@@ -210,7 +210,7 @@
                                         :disabled? read-only}]
 
      [current-project-input "Capacity Workload" [:config :providers :capacity] "number" {:disabled read-only :sub-type :float}]
-     [m/TextFieldHelperText {:persistent true} (str "How many " (or (not-empty (get-in @current-project [:config :demographics :unit-name])) "consumers") " can each provider handle?")]
+     [m/TextFieldHelperText {:persistent true} (str "How many " (or (not-empty (get-in @current-project [:config :demographics :demand-unit])) "targets") " can each provider handle?")]
      (when-not read-only [tag-input])
      [:label "Tags: " [tag-set @tags read-only]]
      [count-providers @tags @current-project]]))
@@ -282,8 +282,8 @@
         analysis-type   (get-in @current-project [:config :analysis-type])
         budget          (get-in @current-project [:config :actions :budget])
         workload        (get-in @current-project [:config :providers :capacity])
-        consumers-unit        (get-in @current-project [:config :demographics :unit-name])
-        capacities       (get-in @current-project [:config :actions :build])]
+        demand-unit     (get-in @current-project [:config :demographics :demand-unit])
+        capacities      (get-in @current-project [:config :actions :build])]
     (dispatch [:sources/load])
     (dispatch [:providers-set/load-providers-set])
     [:section {:class "project-settings-section"}
@@ -310,8 +310,7 @@
                                                      (:capacity action)
                                                      "will provide service for"
                                                      (* (:capacity action) workload)
-                                                     (or (not-empty consumers-unit) "consumers units")
-                                                     " per year"])]) capacities)]))
+                                                     (or (not-empty demand-unit) "targets")])]) capacities)]))
 
 
 (def map-preview-size {:width 373 :height 278})

--- a/common/src/planwise/model/project.cljc
+++ b/common/src/planwise/model/project.cljc
@@ -15,7 +15,8 @@
 (s/def ::source-set-id number?)
 (s/def ::target number?)
 (s/def ::unit-name string?)
-(s/def ::demographics (s/keys :req-un [::unit-name ::target]))
+(s/def ::demand-unit string?)
+(s/def ::demographics (s/keys :req-un [::unit-name ::target ::demand-unit]))
 
 ;; Providers
 (s/def ::provider-set-id (s/nilable number?))

--- a/src/planwise/configuration/templates.clj
+++ b/src/planwise/configuration/templates.clj
@@ -8,7 +8,8 @@
     :defaults {:name "Improve the coverage of meningitis rapid test"
                :config {:coverage {:filter-options {:driving-time 90}} ;How to define Region?
                         :demographics {:target 12
-                                       :unit-name "suspected cases of meningitis"}
+                                       :unit-name "children under 15 years old"
+                                       :demand-unit "suspected cases of meningitis"}
                         :actions {:budget 500000
                                   :build [{:id "build-0"
                                            :capacity 100


### PR DESCRIPTION
Implements #615

* Adds "Demand unit" to "Consumers" tab in the project wizard.
* Replaces "Consumer unit" by "Demand unit" where appropriate.
