### PR TITLE
Add coverage % to each action in the table view for scenarios

### DIFF
--- a/client/resources/sass/site2.scss
+++ b/client/resources/sass/site2.scss
@@ -391,6 +391,7 @@ form.vertical, .fields-vertical {
   hr {
     border: none;
     border-top: 1px solid #e6e6e6;
+    margin: 0;
   }
   /*
   .btn-floating {
@@ -626,8 +627,13 @@ form.vertical, .fields-vertical {
     }
 
     .col-action-description {
-      width: 80%;
+      width: 70%;
       text-align: left;
+    }
+
+    .col-action-coverage {
+      width: 10%;
+      text-align: right;
     }
   }
 }
@@ -915,7 +921,7 @@ form.vertical, .fields-vertical {
 .border-btn-floating {
     position: absolute;
     right: 1rem;
-    margin-top: -2.5rem;
+    margin-top: -2rem;
     z-index: 2;
     border-radius: 50%;
     padding: 3px;
@@ -1128,14 +1134,19 @@ form.vertical, .fields-vertical {
 }
 
 .scenario-settings {
-  margin-left: 18rem;
   button {
     padding: 6px;
   }
 }
+.scenario-title {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
 
 .options-menu {
-   padding: 10px;
+  padding: 10px;
+  margin-left: 17rem;
 }
 
 .template-container {
@@ -1320,6 +1331,7 @@ form.vertical, .fields-vertical {
     background-color: #404040;
     color: white;
     border-radius: 0px 4px 4px 0px;
+    cursor: pointer;
 
     > .sidebar-button-inner {
       position: absolute;

--- a/client/src/planwise/client/scenarios/changeset.cljs
+++ b/client/src/planwise/client/scenarios/changeset.cljs
@@ -81,8 +81,7 @@
         suggestions)])
 
 (defn- changeset-table-row
-  [{:keys [source-demand] :as props}
-   {:keys [name change satisfied-demand reachable-demand] :as provider}]
+  [{:keys [source-demand] :as props} {:keys [name satisfied-demand] :as provider}]
   [:tr
    [:td.col-action-icon [provider-icon provider]]
    [:td.col-action-name name]

--- a/client/src/planwise/client/scenarios/changeset.cljs
+++ b/client/src/planwise/client/scenarios/changeset.cljs
@@ -81,11 +81,13 @@
         suggestions)])
 
 (defn- changeset-table-row
-  [props {:keys [name change] :as provider}]
+  [{:keys [source-demand] :as props}
+   {:keys [name change satisfied-demand reachable-demand] :as provider}]
   [:tr
    [:td.col-action-icon [provider-icon provider]]
    [:td.col-action-name name]
-   [:td.col-action-description (action-description-with-investment props provider)]])
+   [:td.col-action-description (action-description-with-investment props provider)]
+   [:td.col-action-coverage (utils/format-percentage (/ satisfied-demand source-demand) 2)]])
 
 (defn table-component
   [props providers]
@@ -95,7 +97,8 @@
      [:tr
       [:th.col-action-icon]
       [:th.col-action-name "Name"]
-      [:th.col-action-description "Action"]]]
+      [:th.col-action-description "Action"]
+      [:th.col-action-coverage "Coverage"]]]
     [:tbody
      (map (fn [provider]
             ^{:key (str "table-provider-action" (:id provider))} [changeset-table-row props provider])

--- a/client/src/planwise/client/scenarios/views.cljs
+++ b/client/src/planwise/client/scenarios/views.cljs
@@ -289,9 +289,9 @@
                               "loading..."
                               (utils/format-number population-under-coverage))]
     [:div
-     [:div.section
-      [:h1.title-icon name]]
-     [edit/scenario-settings view-state]
+     [:div.section.scenario-title
+      [:h1.title-icon name]
+      [edit/scenario-settings view-state]]
      [:hr]
      [:div.section
       [:h1.large
@@ -418,7 +418,8 @@
     [:div.actions-table-view
      [scenario-line-info current-scenario]
      [changeset/table-component {:demand-unit demand-unit
-                                 :capacity-unit capacity-unit}
+                                 :capacity-unit capacity-unit
+                                 :source-demand (:source-demand current-scenario)}
       @providers-from-changeset]
      [create-new-scenario current-scenario]]))
 


### PR DESCRIPTION
Closes #668

The percentage shown for each action is the new demand covered by the given action over the total demand in the scenario. The sum of the coverage percentages for all actions should equal the percentage increase for the whole scenario.

Minor tweaks to styles:
- move settings button to the right of the scenario title
- reduce margins a bit
- change the cursor on the sidebar expand button to a pointer

![Screenshot from 2021-11-15 17-04-35](https://user-images.githubusercontent.com/733591/141846557-8b3b6bad-8a41-40d5-8cd6-af68ea32bc1b.png)
![Screenshot from 2021-11-15 17-04-48](https://user-images.githubusercontent.com/733591/141846565-caa9da57-e694-47cf-818a-98fd8f4d4aa0.png)
