### PR TITLE
Download scenario sources

### DIFF
--- a/client/resources/sass/site2.scss
+++ b/client/resources/sass/site2.scss
@@ -122,6 +122,14 @@ header {
     > i {
       align-self: center;
     }
+    z-index: 1;
+  }
+
+  .fab-menu {
+    position: absolute;
+    right: $margin-page - 10px;
+    margin-top: 0;
+    z-index: 0;
   }
 }
 

--- a/client/src/planwise/client/scenarios/api.cljs
+++ b/client/src/planwise/client/scenarios/api.cljs
@@ -42,3 +42,11 @@
   [id]
   {:method    :delete
    :uri  (str "/api/scenarios/" id)})
+
+(defn download-scenario-sources
+  [id]
+  (str "/api/scenarios/" id "/sources"))
+
+(defn download-scenario-providers
+  [id]
+  (str "/api/scenarios/" id "/providers"))

--- a/client/src/planwise/client/scenarios/views.cljs
+++ b/client/src/planwise/client/scenarios/views.cljs
@@ -12,6 +12,7 @@
             [planwise.client.routes :as routes]
             [planwise.client.styles :as styles]
             [planwise.client.mapping :as mapping]
+            [planwise.client.scenarios.api :as api]
             [planwise.client.scenarios.edit :as edit]
             [planwise.client.scenarios.changeset :as changeset]
             [planwise.client.components.common :as common]
@@ -432,24 +433,46 @@
      [m/Icon {:strategy "ligature"
               :use (if expanded-sidebar? "arrow_left" "arrow_right")}]]]])
 
+(defn- scenario-download-button
+  [_]
+  (let [popup-open?    (r/atom false)
+        close-popup-fn (fn [] (reset! popup-open? false))
+        menu-item      (fn [label url]
+                         [:a.mdc-list-item
+                          {:role      "menuitem"
+                           :tab-index 0
+                           :on-click  close-popup-fn
+                           :target    "_blank"
+                           :href      url}
+                          label])]
+    (fn [{:keys [scenario-id source-type]}]
+      [:div
+       [:a#main-action.mdc-fab.disable-a
+        {:on-click #(swap! popup-open? not)}
+        [m/Icon {:class "material-icons center-download-icon"} "get_app"]]
+       [m/Menu (when @popup-open? {:class [:mdc-menu--open :fab-menu]})
+        (menu-item (str "Sources " (case source-type
+                                     "raster" "(TIF)"
+                                     "(CSV)"))
+                   (api/download-scenario-sources scenario-id))
+        (menu-item "Providers (CSV)" (api/download-scenario-providers scenario-id))]])))
+
 (defn display-current-scenario
   [current-project {:keys [id] :as current-scenario}]
-  (let [read-only?  (subscribe [:scenarios/read-only?])
-        state       (subscribe [:scenarios/view-state])
-        error       (subscribe [:scenarios/error])
-        export-providers-button [:a {:class "mdc-fab disable-a"
-                                     :id "main-action"
-                                     :href (str "/api/scenarios/" id "/csv")}
-                                 [m/Icon {:class "material-icons  center-download-icon"} "get_app"]]]
+  (let [read-only?              (subscribe [:scenarios/read-only?])
+        state                   (subscribe [:scenarios/view-state])
+        error                   (subscribe [:scenarios/error])
+        export-providers-button [scenario-download-button {:scenario-id id
+                                                           :source-type (:source-type current-project)}]]
     (fn [current-project current-scenario]
       (let [expanded-sidebar? (= @state :show-actions-table)]
         [ui/full-screen (merge (common2/nav-params)
-                               {:main-prop {:style {:position :relative}}
-                                :main [simple-map current-project current-scenario @state @error @read-only?]
-                                :title [:ul {:class-name "breadcrumb-menu"}
-                                        [:li [:a {:href (routes/projects2-show {:id (:id current-project)})} (:name current-project)]]
-                                        [:li [m/Icon {:strategy "ligature" :use "keyboard_arrow_right"}]]
-                                        [:li (:name current-scenario)]]
+                               {:main-prop    {:style {:position :relative}}
+                                :main         [simple-map current-project current-scenario @state @error @read-only?]
+                                :title        [:ul {:class-name "breadcrumb-menu"}
+                                               [:li [:a {:href (routes/projects2-show {:id (:id current-project)})} (:name current-project)]]
+                                               [:li [m/Icon {:strategy "ligature" :use "keyboard_arrow_right"}]]
+                                               [:li (:name current-scenario)]]
                                 :sidebar-prop {:class [(if expanded-sidebar? :expanded-sidebar :compact-sidebar)]}}
                                (when-not expanded-sidebar?
                                  {:action export-providers-button}))

--- a/src/planwise/boundary/scenarios.clj
+++ b/src/planwise/boundary/scenarios.clj
@@ -33,6 +33,9 @@
   (export-providers-data [this project scenario]
     "Create CSV file with scenario's demand information for computed and disabled providers")
 
+  (export-sources-data [this project scenario]
+    "Create CSV file with scenario's demand information for point sources. Fails if the project is of type raster.")
+
   (get-suggestions-for-new-provider-location [store project scenario]
     "Get list of locations suggested for creating new provider")
 

--- a/src/planwise/endpoint/scenarios.clj
+++ b/src/planwise/endpoint/scenarios.clj
@@ -43,23 +43,23 @@
            (header "Content-Disposition" (str "attachment; filename=" csv-name)))))
 
    (GET "/:id/sources" [id :as request]
-        (let [user-id  (util/request-user-id request)
-              id       (Integer. id)
-              {:keys [project-id] :as scenario} (scenarios/get-scenario service id)
-              project  (filter-owned-by (projects2/get-project projects2 project-id) user-id)]
-          (if (or (nil? project) (nil? scenario))
-            (not-found {:error "Scenario not found"})
-            (if (common/is-project-raster? project)
-              (let [tif-name (str project-id "-" id "-" (:name scenario) ".source.tif")
-                    tif-file (common/scenario-raster-full-path (:raster scenario))]
-                (-> (file-response tif-file)
-                    (content-type "image/tiff")
-                    (header "Content-Disposition" (str "attachment; filename=" tif-name))))
-              (let [csv-name (str project-id "-" id "-" (:name scenario) ".sources.csv")
-                    csv-data (scenarios/export-sources-data service project scenario)]
-                (-> (response csv-data)
-                    (content-type "text/csv")
-                    (header "Content-Disposition" (str "attachment; filename=" csv-name))))))))
+     (let [user-id  (util/request-user-id request)
+           id       (Integer. id)
+           {:keys [project-id] :as scenario} (scenarios/get-scenario service id)
+           project  (filter-owned-by (projects2/get-project projects2 project-id) user-id)]
+       (if (or (nil? project) (nil? scenario))
+         (not-found {:error "Scenario not found"})
+         (if (common/is-project-raster? project)
+           (let [tif-name (str project-id "-" id "-" (:name scenario) ".source.tif")
+                 tif-file (common/scenario-raster-full-path (:raster scenario))]
+             (-> (file-response tif-file)
+                 (content-type "image/tiff")
+                 (header "Content-Disposition" (str "attachment; filename=" tif-name))))
+           (let [csv-name (str project-id "-" id "-" (:name scenario) ".sources.csv")
+                 csv-data (scenarios/export-sources-data service project scenario)]
+             (-> (response csv-data)
+                 (content-type "text/csv")
+                 (header "Content-Disposition" (str "attachment; filename=" csv-name))))))))
 
    (GET "/:id/suggested-locations" [id :as request]
      (let [user-id  (util/request-user-id request)

--- a/src/planwise/endpoint/scenarios.clj
+++ b/src/planwise/endpoint/scenarios.clj
@@ -3,11 +3,12 @@
             [integrant.core :as ig]
             [taoensso.timbre :as timbre]
             [clojure.spec.alpha :as s]
-            [ring.util.response :refer [response status not-found header]]
+            [ring.util.response :refer [response status not-found header content-type file-response]]
             [planwise.util.ring :as util]
             [buddy.auth :refer [authenticated?]]
             [buddy.auth.accessrules :refer [restrict]]
             [clojure.core.reducers :as r]
+            [planwise.engine.common :as common]
             [planwise.boundary.scenarios :as scenarios]
             [planwise.boundary.projects2 :as projects2]))
 
@@ -30,14 +31,35 @@
          (not-found {:error "Scenario not found"})
          (response (scenarios/get-scenario-for-project service scenario project)))))
 
-   (GET "/:id/csv" [id :as request]
+   (GET "/:id/providers" [id :as request]
      (let [user-id  (util/request-user-id request)
            id       (Integer. id)
            {:keys [project-id] :as scenario} (scenarios/get-scenario service id)
            project  (filter-owned-by (projects2/get-project projects2 project-id) user-id)
-           csv-name (str (:id project) "-" id "-" (:name scenario) ".csv")
-           response (response (scenarios/export-providers-data service project scenario))]
-       (header response "Content-Disposition" (str "attachment; filename=" csv-name))))
+           csv-name (str project-id "-" id "-" (:name scenario) ".providers.csv")
+           csv-data (scenarios/export-providers-data service project scenario)]
+       (-> (response csv-data)
+           (content-type "text/csv")
+           (header "Content-Disposition" (str "attachment; filename=" csv-name)))))
+
+   (GET "/:id/sources" [id :as request]
+        (let [user-id  (util/request-user-id request)
+              id       (Integer. id)
+              {:keys [project-id] :as scenario} (scenarios/get-scenario service id)
+              project  (filter-owned-by (projects2/get-project projects2 project-id) user-id)]
+          (if (or (nil? project) (nil? scenario))
+            (not-found {:error "Scenario not found"})
+            (if (common/is-project-raster? project)
+              (let [tif-name (str project-id "-" id "-" (:name scenario) ".source.tif")
+                    tif-file (common/scenario-raster-full-path (:raster scenario))]
+                (-> (file-response tif-file)
+                    (content-type "image/tiff")
+                    (header "Content-Disposition" (str "attachment; filename=" tif-name))))
+              (let [csv-name (str project-id "-" id "-" (:name scenario) ".sources.csv")
+                    csv-data (scenarios/export-sources-data service project scenario)]
+                (-> (response csv-data)
+                    (content-type "text/csv")
+                    (header "Content-Disposition" (str "attachment; filename=" csv-name))))))))
 
    (GET "/:id/suggested-locations" [id :as request]
      (let [user-id  (util/request-user-id request)


### PR DESCRIPTION
Closes #667 

Allow downloading the scenario sources (as well as providers). This adds a popup menu to the download button to select what to download: sources or providers. When downloading sources, depending on the project source type, raster or points, either a `.tif` file or a `.csv` file are generated.

![Screenshot from 2021-11-16 12-45-26](https://user-images.githubusercontent.com/733591/142018224-64d49294-5036-4099-9954-cbb7491526a9.png)
