### PR TITLE
Improve map markers and add tooltip with the name of the provider/source

### DIFF
--- a/client/resources/sass/site2.scss
+++ b/client/resources/sass/site2.scss
@@ -998,6 +998,31 @@ form.vertical, .fields-vertical {
     }
 }
 
+.leaflet-popup-content {
+  > div {
+    overflow: auto;
+  }
+  p {
+    margin: 0;
+  }
+  h3 {
+    font-weight: bold;
+  }
+  .actions {
+    margin-top: 1rem;
+  }
+  table {
+    border-collapse: collapse;
+    width: 100%;
+    td {
+      white-space: nowrap;
+    }
+    tr:nth-child(odd) {
+      background-color: #f0f0f0;
+    }
+  }
+}
+
 .leaflet-square-icon-gray {
   border: 1px solid rgba(211, 211, 211, 0.53) !important;
   background: rgba(189, 187, 187, 0.447);

--- a/client/resources/sass/site2.scss
+++ b/client/resources/sass/site2.scss
@@ -1086,27 +1086,34 @@ form.vertical, .fields-vertical {
 
   &.idle-capacity {
     background-color: #00bcd4;
+    border: 1px #00727e solid;
   }
   &.at-capacity {
     background-color: #4caf50;
+    border: 1px #327134 solid;
   }
   &.small-unsatisfied {
     background-color: #ffeb3b;
+    border: 1px #ecca00 solid;
+
   }
   &.mid-unsatisfied {
     background-color: #ffc107;
+    border: 1px #b88a00 solid;
   }
   &.unsatisfied {
     background-color: #ff5722;
+    border: 1px #8f2100 solid;
   }
   &.not-matching {
     background-color: #999;
+    border: 1px black solid;
   }
   &.selected[style] {
-    width: 20px !important;
-    height: 20px !important;
-    margin-left: -10px !important;
-    margin-top: -10px !important;
+    width: 24px !important;
+    height: 24px !important;
+    margin-left: -12px !important;
+    margin-top: -12px !important;
     border: 4px white solid !important;
   }
 }

--- a/client/src/planwise/client/scenarios/views.cljs
+++ b/client/src/planwise/client/scenarios/views.cljs
@@ -193,7 +193,7 @@
                                                      :group {:pane "tilePane"}
                                                      :lat-fn (fn [polygon-point] (:lat polygon-point))
                                                      :lon-fn (fn [polygon-point] (:lon polygon-point))
-                                                     :color :orange
+                                                     :color "#40404080"
                                                      :stroke true}]
             suggestions-layer       [:marker-layer {:points (map #(assoc % :open? (= % selected-suggestion)) suggested-locations)
                                                     :lat-fn #(get-in % [:location :lat])

--- a/client/src/planwise/client/scenarios/views.cljs
+++ b/client/src/planwise/client/scenarios/views.cljs
@@ -57,21 +57,35 @@
     (crate/html
      [:div
       [:h3 name]
-      [:p (str "Capacity: " (utils/format-number capacity) " " capacity-unit)]
-      [:p (str "Unsatisfied demand: " (utils/format-number unsatisfied-demand))]
-      [:p (str "Required capacity: " (utils/format-number (Math/ceil required-capacity)))]
-      (when (or matches-filters change)
-        [:p (str "Satisfied demand: " (utils/format-number satisfied-demand))])
-      (when (or matches-filters change)
-        [:p (str "Free capacity: " (utils/format-number (Math/floor free-capacity)))])
-      [:p (str (capitalize demand-unit) " under geographic coverage: " (utils/format-number (Math/ceil reachable-demand)))]
+      [:table
+       [:tr
+        [:td "Capacity:"]
+        [:td (str (utils/format-number capacity) " " capacity-unit)]]
+       [:tr
+        [:td "Unsatisfied demand:"]
+        [:td (utils/format-number unsatisfied-demand)]]
+       [:tr
+        [:td "Required capacity:"]
+        [:td (utils/format-number (Math/ceil required-capacity))]]
+       (when (or matches-filters change)
+         [:tr
+          [:td "Satisfied demand:"]
+          [:td (utils/format-number satisfied-demand)]])
+       (when (or matches-filters change)
+         [:tr
+          [:td "Free capacity: "]
+          [:td (utils/format-number (Math/floor free-capacity))]])
+       [:tr
+        [:td (str (capitalize demand-unit) " under coverage:")]
+        [:td (utils/format-number (Math/ceil reachable-demand))]]]
       (when-not read-only?
-        (popup-connected-button
-         (cond
-           (some? change)        "Edit"
-           (not matches-filters) "Upgrade"
-           :else                 "Increase")
-         #(dispatch [:scenarios/edit-change (assoc provider :change change*)])))])))
+        [:div.actions
+         (popup-connected-button
+          (cond
+            (some? change)        "Edit"
+            (not matches-filters) "Upgrade"
+            :else                 "Increase")
+          #(dispatch [:scenarios/edit-change (assoc provider :change change*)]))])])))
 
 (defn label-for-suggestion
   [suggestion state]
@@ -95,19 +109,34 @@
     (crate/html
      [:div
       [:h3 (if name name (str "Suggestion " ranked))]
-      [:p (str "Needed capacity : " (utils/format-number (Math/ceil action-capacity)) " " capacity-unit)]
-      (when new-provider?
-        [:p (str "Expected demand to satisfy : " (utils/format-number coverage) " " demand-unit)])
-      (when-not new-provider?
-        (when action-cost
-          [:p (str "Investment according to project configuration : " (utils/format-number action-cost))]))
-      (button-for-suggestion (label-for-suggestion suggestion state) suggestion)])))
+      [:table
+       [:tr
+        [:td "Needed capacity : "]
+        [:td (str (utils/format-number (Math/ceil action-capacity)) " " capacity-unit)]]
+       (when new-provider?
+         [:tr
+          [:td "Expected demand to satisfy:"]
+          [:td (str (utils/format-number coverage) " " demand-unit)]])
+       (when (and (not new-provider?) action-cost)
+         [:tr
+          [:td "Estimated investment:"]
+          [:td (utils/format-number action-cost)]])]
+      [:div.actions (button-for-suggestion (label-for-suggestion suggestion state) suggestion)]])))
 
 (defn- show-source
   [{{:keys [name initial-quantity quantity]} :elem :as source}]
-  (str "<b>" (utils/escape-html (str name)) "</b>"
-       "<br> Original quantity: " (.toFixed (or initial-quantity 0) 2)
-       "<br> Current quantity: " (.toFixed (or quantity 0) 2)))
+  (let [display-initial-quantity (.toFixed (or initial-quantity 0) 2)
+        display-quantity         (.toFixed (or quantity 0) 2)]
+    (crate/html
+     [:div
+      [:h3 name]
+      [:table
+       [:tr
+        [:td "Original quantity:"]
+        [:td display-initial-quantity]]
+       [:tr
+        [:td "Current quantity:"]
+        [:td display-quantity]]]])))
 
 (defn- to-indexed-map
   [coll]
@@ -177,6 +206,7 @@
                                                     :shape :square
                                                     :lat-fn #(get-in % [:elem :lat])
                                                     :lon-fn #(get-in % [:elem :lon])
+                                                    :label-fn (comp :name :elem)
                                                     :icon-fn #(let [source (:elem %)
                                                                     quantity-initial (:initial-quantity source)
                                                                     quantity-current (:quantity source)
@@ -207,6 +237,7 @@
             providers-layer [providers-layer-type {:points (map #(assoc % :open? (= % @selected-provider)) @all-providers)
                                                    :lat-fn #(get-in % [:location :lat])
                                                    :lon-fn #(get-in % [:location :lon])
+                                                   :label-fn :name
                                                    :icon-fn #(icon-function % @selected-provider)
                                                    :popup-fn     #(show-provider {:read-only? read-only?
                                                                                   :demand-unit demand-unit


### PR DESCRIPTION
- Improve the contrast and visibility of provider markers by adding a thin darker border
- Show a tooltip next to each provider/source/suggestion with the name of the entity
- Improve the style of the popup information by using a table
- Change the color of the coverage polygon to a neutral gray

![marker-popups](https://user-images.githubusercontent.com/733591/142271628-0052115e-d61c-4eaf-a451-9fb2f8a43410.png)
![provider-labels](https://user-images.githubusercontent.com/733591/142271643-d4a52f47-9c88-4420-b6b6-d8c898d511e8.png)


