### PR TITLE
Allow searching existing and new providers in the map

### DIFF
--- a/client/resources/sass/site2.scss
+++ b/client/resources/sass/site2.scss
@@ -1380,3 +1380,36 @@ form.vertical, .fields-vertical {
     }
   }
 }
+
+.sidebar-search {
+  position: absolute;
+  background-color: #404040;
+  border-radius: 0px 4px 4px 0px;
+  left: 100%;
+  bottom: 1rem;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  height: 48px;
+  color: white;
+  > .sidebar-button {
+    cursor: pointer;
+  }
+  input[type=text] {
+    font-size: 100%;
+    height: 32px;
+    margin-left: 10px;
+    margin-right: 4px;
+    border-radius: 4px;
+    padding: 0px 8px;
+    background-color: #606060;
+    color: white;
+    border: none;
+    &::placeholder {
+      color: #e0e0e0;
+    }
+  }
+  span {
+    margin: 0px 4px;
+  }
+}

--- a/client/src/planwise/client/scenarios/db.cljs
+++ b/client/src/planwise/client/scenarios/db.cljs
@@ -13,8 +13,8 @@
    :list-scope               nil
    :list                     (asdf/new nil)
    :sort-column              nil
-   :sort-order               nil})
-
+   :sort-order               nil
+   :providers-search         nil})
 
 (defmulti new-action :action-name)
 

--- a/client/src/planwise/client/scenarios/subs.cljs
+++ b/client/src/planwise/client/scenarios/subs.cljs
@@ -165,3 +165,10 @@
  :scenarios/sort-order
  (fn [db _]
    (get-in db [:scenarios :sort-order])))
+
+(rf/reg-sub
+ :scenarios/search-providers-matches
+ (fn [db _]
+   (let [{:keys [occurrence match-count]} (get-in db [:scenarios :providers-search])]
+     (when (pos? match-count)
+       [(inc occurrence) match-count]))))


### PR DESCRIPTION
Closes #666

Add a floating search button to the sidebar to search providers by name. Results may include new providers as created from scenario changes. If a search has multiple matching results, repeating the search (ie. pressing Enter on the search box) will cycle them.

![2021-11-17-18-43-47](https://user-images.githubusercontent.com/733591/142288583-dd9c1349-13a3-426c-b471-3a3c7ffd0220.gif)
