### PR TITLE
Cache coverage geometries for providers in the client

### DIFF
--- a/client/src/planwise/client/scenarios/db.cljs
+++ b/client/src/planwise/client/scenarios/db.cljs
@@ -9,6 +9,7 @@
    :changeset-dialog         nil
    :selected-provider        nil
    :selected-suggestion      nil
+   :coverage-cache           nil
    :list-scope               nil
    :list                     (asdf/new nil)
    :sort-column              nil

--- a/client/src/planwise/client/scenarios/subs.cljs
+++ b/client/src/planwise/client/scenarios/subs.cljs
@@ -42,7 +42,8 @@
 (rf/reg-sub
  :scenarios.map/selected-provider
  (fn [db _]
-   (get-in db [:scenarios :selected-provider])))
+   (when-let [provider (get-in db [:scenarios :selected-provider])]
+     (assoc provider :coverage-geom (get-in db [:scenarios :coverage-cache (:id provider)])))))
 
 (rf/reg-sub
  :scenarios.map/selected-suggestion


### PR DESCRIPTION
Avoid requesting the same geometry multiple times from the backend as the provider is selected/unselected. This should improve perceived performance and save bandwidth.

