### PR TITLE
Refactor: clean up scenario map code and extract layers into functions

### DIFF
--- a/client/resources/sass/site2.scss
+++ b/client/resources/sass/site2.scss
@@ -477,6 +477,9 @@ form.vertical, .fields-vertical {
 
 .changeset-row {
   cursor: pointer;
+  &:hover {
+    background-color: #f0f0f0;
+  }
 }
 
 .scenarios-content {

--- a/client/src/planwise/client/projects2/components/settings.cljs
+++ b/client/src/planwise/client/projects2/components/settings.cljs
@@ -463,10 +463,8 @@
                             :controls []
                             :initial-bbox bbox}
               mapping/default-base-tile-layer
-              [:geojson-layer {:data  @region-geo}
+              [:geojson-layer {:data @region-geo}
                :group {:pane "tilePane"}
-               :lat-fn (fn [polygon-point] (:lat polygon-point))
-               :lon-fn (fn [polygon-point] (:lon polygon-point))
                :color :orange
                :stroke true]])]]]))))
 

--- a/client/src/planwise/client/scenarios/changeset.cljs
+++ b/client/src/planwise/client/scenarios/changeset.cljs
@@ -40,9 +40,10 @@
   [props {:keys [name change] :as provider}]
   (let [action (:action change)]
     [:div
-     [:div.section.changeset-row {:on-mouse-over  #(dispatch [:scenarios.map/select-provider provider])
-                                  :on-mouse-leave #(dispatch [:scenarios.map/unselect-provider provider])
-                                  :on-click       #(dispatch [:scenarios/open-changeset-dialog provider])}
+     [:div.section.changeset-row
+      {:on-mouse-over  #(dispatch [:scenarios.map/select-provider (assoc provider :open? true)])
+       :on-mouse-leave #(dispatch [:scenarios.map/unselect-provider provider])
+       :on-click       #(dispatch [:scenarios/open-changeset-dialog provider])}
       [:div.icon-list
        [m/Icon {} (get action-icons action)]
        [:div.icon-list-text

--- a/client/src/planwise/client/scenarios/changeset.cljs
+++ b/client/src/planwise/client/scenarios/changeset.cljs
@@ -40,9 +40,9 @@
   [props {:keys [name change] :as provider}]
   (let [action (:action change)]
     [:div
-     [:div.section.changeset-row {:on-mouse-over #(dispatch [:scenarios.map/select-provider provider])
-                                  :on-mouse-out  #(dispatch [:scenarios.map/unselect-provider provider])
-                                  :on-click      #(dispatch [:scenarios/open-changeset-dialog provider])}
+     [:div.section.changeset-row {:on-mouse-over  #(dispatch [:scenarios.map/select-provider provider])
+                                  :on-mouse-leave #(dispatch [:scenarios.map/unselect-provider provider])
+                                  :on-click       #(dispatch [:scenarios/open-changeset-dialog provider])}
       [:div.icon-list
        [m/Icon {} (get action-icons action)]
        [:div.icon-list-text

--- a/client/src/planwise/client/scenarios/views.cljs
+++ b/client/src/planwise/client/scenarios/views.cljs
@@ -125,7 +125,7 @@
       [:div.actions (button-for-suggestion (label-for-suggestion suggestion state) suggestion)]])))
 
 (defn- show-source
-  [{{:keys [name initial-quantity quantity]} :elem :as source}]
+  [{:keys [name initial-quantity quantity]}]
   (let [display-initial-quantity (.toFixed (or initial-quantity 0) 2)
         display-quantity         (.toFixed (or quantity 0) 2)]
     (crate/html
@@ -138,10 +138,6 @@
        [:tr
         [:td "Current quantity:"]
         [:td display-quantity]]]])))
-
-(defn- to-indexed-map
-  [coll]
-  (map-indexed (fn [idx elem] {:elem elem :index idx}) coll))
 
 (defn- get-percentage
   [total relative]
@@ -215,10 +211,6 @@
                                                             provider))
         provider-mouseover-fn (fn [provider] (dispatch [:scenarios.map/select-provider provider]))
         provider-mouseout-fn  (fn [provider] (dispatch [:scenarios.map/unselect-provider provider]))
-        source-lat-fn         (fn [source] (get-in source [:elem :lat]))
-        source-lon-fn         (fn [source] (get-in source [:elem :lon]))
-        source-popup-fn       (fn [source] (show-source source))
-        source-icon-fn        (fn [source] (source-icon-function (:elem source)))
         suggestion-popup-fn   (fn [suggestion]
                                 (show-suggested-provider {:demand-unit   demand-unit
                                                           :capacity-unit capacity-unit}
@@ -230,17 +222,13 @@
                                                   "leaflet-suggestion-new-improvement")]
                                   (suggestion-icon-fn suggestion selected-suggestion classname)))]
     (fn [{:keys [bbox] :as project} {:keys [changeset raster sources-data] :as scenario} state error read-only?]
-      (let [indexed-providers       (to-indexed-map @all-providers)
-            indexed-sources         (to-indexed-map sources-data)
-            pending-demand-raster   raster
+      (let [pending-demand-raster   raster
             suggested-locations     @suggested-locations
             selected-suggestion     @selected-suggestion
-            sources-layer           [:marker-layer {:points   indexed-sources
+            sources-layer           [:marker-layer {:points   sources-data
                                                     :shape    :square
-                                                    :lat-fn   source-lat-fn
-                                                    :lon-fn   source-lon-fn
-                                                    :icon-fn  source-icon-fn
-                                                    :popup-fn source-popup-fn}]
+                                                    :icon-fn  source-icon-function
+                                                    :popup-fn show-source}]
             selected-provider-layer [:geojson-layer {:data   (:coverage-geom @selected-provider)
                                                      :group  {:pane "tilePane"}
                                                      :color  "#40404080"

--- a/client/src/planwise/client/scenarios/views.cljs
+++ b/client/src/planwise/client/scenarios/views.cljs
@@ -239,7 +239,12 @@
                                                                     (dispatch [:scenarios.map/select-suggestion suggestion]))
                                                     :mouseout-fn  (fn [suggestion]
                                                                     (dispatch [:scenarios.map/unselect-suggestion suggestion]))}]
-            providers-layer         [:marker-layer {:points       (map #(assoc % :open? (= (:id %) (:id @selected-provider))) @all-providers)
+            provider-points         (->> @all-providers
+                                         (map (fn [{:keys [id] :as provider}]
+                                                (if (= id (:id @selected-provider))
+                                                  (assoc provider :open? (:open? @selected-provider))
+                                                  provider))))
+            providers-layer         [:marker-layer {:points       provider-points
                                                     :lat-fn       provider-lat-fn
                                                     :lon-fn       provider-lon-fn
                                                     :icon-fn      provider-icon-fn


### PR DESCRIPTION
Applies on #681 

- Extract all functions used as layer parameters to avoid re-rendering the map even without changing (since reagent will check attributes for equality and functions are compared by reference)
- Extract all layers in the scenario map view as functions
- Open the provider popup when hovering over the changeset table
