### PR TITLE
Reorganize scenario actions

### DIFF
--- a/client/resources/sass/site2.scss
+++ b/client/resources/sass/site2.scss
@@ -439,27 +439,6 @@ form.vertical, .fields-vertical {
       margin-top: -1rem;
     }
   }
-  .btn-create {
-    font-size: 1rem;
-    line-height: 0;
-    color: #FF5722;
-    text-transform: uppercase;
-    text-align: center;
-    padding: 2rem 0;
-    position: absolute;
-    bottom: 0;
-    width: 100%;
-  }
-
-  .actions-table-view > .btn-create {
-    width: fit-content;
-    padding: 2rem;
-    right: 0rem;
-  }
-}
-
-#sidebar.expanded-sidebar {
-  padding-bottom: 4rem;
 }
 
 .icon-list {
@@ -1422,4 +1401,16 @@ form.vertical, .fields-vertical {
   span {
     margin: 0px 4px;
   }
+}
+
+.mdc-menu__items {
+  .mdc-list-item--disabled {
+    cursor: default;
+    color: #b0b0b0;
+    pointer-events: none;
+  }
+}
+
+.mdc-menu {
+  z-index: 3000;
 }

--- a/client/resources/sass/site2.scss
+++ b/client/resources/sass/site2.scss
@@ -29,6 +29,21 @@ body {
 
 }
 
+#app {
+  height: 100vh;
+  width: 100%;
+  display: flex;
+  > div {
+    flex: 1;
+  }
+  .loading-wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+  }
+}
+
 // Fix for jumpy text on header's toolbar when a select is closed
 body.mdc-select-scroll-lock {
   overflow: unset;
@@ -61,9 +76,9 @@ body.mdc-select-scroll-lock {
   grid-template-rows: min-content 30px auto 20px 30px;
   grid-template-areas:
     "header header header header"
-    "main   main   main main"
-    "main   main   main main"
-    "main   main   main main"
+    "main   main   main   main"
+    "main   main   main   main"
+    "main   main   main   main"
     "footer footer footer footer";
 }
 

--- a/client/resources/sass/site2.scss
+++ b/client/resources/sass/site2.scss
@@ -55,9 +55,10 @@ body.mdc-select-scroll-lock {
 .layout.full-screen {
   height: 100vh;
   font-size: 1rem;
+  align-self: center;
   display: grid;
   grid-template-columns: 30px 370px auto 40px;
-  grid-template-rows: min-content 30px auto 20px 40px;
+  grid-template-rows: min-content 30px auto 20px 30px;
   grid-template-areas:
     "header header header header"
     "main   main   main main"
@@ -88,6 +89,7 @@ header {
   #section-row {
     display: flex;
     justify-content: flex-start;
+    align-items: center;
     * {
       margin-right: 48px;
       font-size: 16px;
@@ -141,16 +143,22 @@ main {
 
 footer {
   grid-area: footer;
-  padding: 14px 14px;
+  display: flex;
+  align-items: center;
+  padding: 0px 14px;
   border-top: 1px solid $material-color-grey-300;
   font-size: $small-font-size;
 }
 
 .layout.full-screen {
   aside#sidebar {
-    z-index: 9999;
+    z-index: 2000;
     @include mdc-elevation(2);
     background: #ffffff;
+    position: relative;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
   }
 
   aside#sidebar.compact-sidebar {
@@ -181,6 +189,7 @@ header.mdc-toolbar {
 #account-menu {
   @include link-color(#9a9a9a);
   display: inline-flex !important;
+  align-items: center;
   .icon-dropdown{
     margin-left: 4px;
   }
@@ -197,6 +206,7 @@ filter: grayscale(100%);
 
 #secondary-actions-handle {
   @include link-color(#9a9a9a);
+  margin-left: 10px;
 }
 
 #tabs-row {
@@ -369,7 +379,6 @@ form.vertical, .fields-vertical {
 
 #sidebar {
   position: relative;
-  padding-bottom: 3rem;
   .section {
     padding: 1rem;
   }
@@ -401,23 +410,13 @@ form.vertical, .fields-vertical {
     border-top: 1px solid #e6e6e6;
     margin: 0;
   }
-  /*
-  .btn-floating {
-    position: absolute;
-    right: 1rem;
-    margin-top: -2.4rem;
-    z-index: 2;
-  }
-  */
 
   .suggestion-list {
     max-height: 490px !important;
   }
 
   .scroll-list {
-    max-height: 280px;
     width: 100%;
-    margin-top: 2rem;
     overflow-y: auto;
     overflow-x: hidden;
     position: relative;
@@ -427,7 +426,6 @@ form.vertical, .fields-vertical {
     height: 1rem;
     width: 100%;
     position: absolute;
-    margin-top: 1.5rem;
     z-index: 1;
 
     background: -moz-linear-gradient(top, rgba(255,255,255,1) 0%, rgba(255,255,255,1) 20%, rgba(255,255,255,0) 99%, rgba(255,255,255,0) 100%); /* FF3.6-15 */
@@ -463,6 +461,7 @@ form.vertical, .fields-vertical {
 
 .scenarios-content {
   padding: 0px;
+  overflow: auto;
 
   table {
     border-spacing: 0;
@@ -511,7 +510,7 @@ form.vertical, .fields-vertical {
       th {
         color: #999999;
         text-align: left;
-        padding: 24px 20px 11px 20px;
+        padding: 11px 20px 11px 20px;
         font-weight: 500;
         font-size: 1rem;
       }
@@ -904,7 +903,7 @@ form.vertical, .fields-vertical {
 
 .suggestion-list {
   .border-btn-floating {
-      margin-top: -1.8rem !important;
+    margin-top: -1.8rem !important;
   }
 }
 
@@ -915,12 +914,6 @@ form.vertical, .fields-vertical {
     z-index: 2;
     border-radius: 50%;
     padding: 3px;
-
-    .btn-floating {
-        z-index: 2;
-        border: 1px solid #FFF;
-        box-shadow: none;
-    }
 }
 
 .border-btn-floating button {
@@ -1334,22 +1327,21 @@ form.vertical, .fields-vertical {
 
 .actions-table-header {
   border-bottom: 1px solid #ccc;
-}
-
-.actions-table-scenario-info {
-  display: flex;
-  flex-direction: row;
-  align-items: baseline;
-
   > div {
-    padding: 0 1rem 0 1rem;
+    height: 64px;
+    padding: 0 1rem;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    > h3 {
+      margin-right: 2rem;
+    }
   }
 }
 
 .sidebar-expand-button {
   position: absolute;
   right: -24px;
-  top: 1rem;
 
   > .sidebar-button {
     position: relative;
@@ -1375,7 +1367,7 @@ form.vertical, .fields-vertical {
   background-color: #404040;
   border-radius: 0px 4px 4px 0px;
   left: 100%;
-  bottom: 1rem;
+  bottom: 0;
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/client/src/planwise/client/components/common2.cljs
+++ b/client/src/planwise/client/components/common2.cljs
@@ -15,7 +15,7 @@
   []
   (let [page (subscribe [:current-page])
         active? (fn [pages] (contains? pages @page))]
-    {:sections [[ui/section {:href (routes/projects2) :active (active? #{:projects2 :scenario})} "Projects"]
+    {:sections [[ui/section {:href (routes/projects2) :active (active? #{:projects2 :scenarios})} "Projects"]
                 [ui/section {:href (routes/providers-set) :active (active? #{:providers-set})} "Providers"]
                 [ui/section {:href (routes/sources) :active (active? #{:sources})} "Sources"]]
 

--- a/client/src/planwise/client/projects2/components/dashboard.cljs
+++ b/client/src/planwise/client/projects2/components/dashboard.cljs
@@ -26,8 +26,12 @@
 
 (defn- project-secondary-actions
   [project delete?]
-  [[ui/secondary-action {:on-click #(dispatch [:projects2/reset-project (:id project)])} "Back to draft"]
-   [ui/secondary-action {:on-click #(reset! delete? true)} "Delete project"]])
+  [[ui/menu-item {:on-click #(dispatch [:projects2/reset-project (:id project)])
+                  :icon     "undo"}
+    "Back to draft"]
+   [ui/menu-item {:on-click #(reset! delete? true)
+                  :icon     "delete"}
+    "Delete project"]])
 
 (defn- create-chip
   [input]

--- a/client/src/planwise/client/scenarios/edit.cljs
+++ b/client/src/planwise/client/scenarios/edit.cljs
@@ -191,24 +191,6 @@
        {:on-click #(dispatch [:scenarios.new-action/fetch-suggested-providers-to-improve])}
        (str "Get suggestions to improve existing " provider-unit)]]]))
 
-(defn scenario-settings
-  [state]
-  (let [open (subscribe [:scenarios/scenario-menu-settings])]
-    (fn [state]
-      [:div.scenario-settings
-       [m/Button
-        {:on-click #(dispatch [:scenarios/show-scenario-settings])}
-        [m/Icon "settings"]]
-       [m/MenuAnchor
-        [:div]
-        [m/Menu (when @open {:class "mdc-menu--open"})
-         [m/MenuItem
-          {:on-click  #(dispatch [:scenarios/open-rename-dialog])}
-          "Rename scenario"]
-         [m/MenuItem
-          {:on-click #(dispatch [:scenarios/open-delete-dialog])}
-          "Delete scenario"]]]])))
-
 (defn delete-scenario-dialog
   [state current-scenario]
   [dialog {:open? (= state :delete-scenario)

--- a/client/src/planwise/client/scenarios/views.cljs
+++ b/client/src/planwise/client/scenarios/views.cljs
@@ -397,9 +397,7 @@
   [:<>
    [:div.section
     [:h1.title-icon "Suggestion list"]]
-   [:div.fade]
-   [changeset/suggestion-listing-component props suggested-locations]
-   [:div.fade.inverted]])
+   [changeset/suggestion-listing-component props suggested-locations]])
 
 (defn new-provider-unit?
   [view-state]
@@ -448,11 +446,9 @@
      (if error
        [raise-alert scenario error]
        [:<>
-        [:div.fade]
         [changeset/listing-component {:demand-unit demand-unit
                                       :capacity-unit capacity-unit}
-         providers]
-        [:div.fade.inverted]])]))
+         providers]])]))
 
 (defn side-panel-view-2
   [current-scenario error]
@@ -482,15 +478,16 @@
      [side-panel-view-2 current-scenario error])])
 
 (defn scenario-line-info
-  [{:keys [name effort source-demand increase-coverage] :as current-scenario}]
+  [{:keys [effort source-demand increase-coverage] :as current-scenario}]
   (let [current-project (subscribe [:projects2/current-project])
         analysis-type   (get-in @current-project [:config :analysis-type])
         demand-unit     (get-demand-unit @current-project)]
-    [:div.section.actions-table-header
-     [:div.actions-table-scenario-info
-      [:div [:h3 name]]
-      [:div [:h3.grey-text (str "Increase in " demand-unit " coverage " (utils/format-number increase-coverage) " (" (format-percentage increase-coverage source-demand) ")")]]
-      [:div [:h3.grey-text (str "Effort required " (utils/format-effort effort analysis-type))]]]]))
+    [:div.actions-table-header
+     [:div
+      [:h3.grey-text (str "Increase in " demand-unit " coverage "
+                          (utils/format-number increase-coverage)
+                          " (" (format-percentage increase-coverage source-demand) ")")]
+      [:h3.grey-text (str "Effort required " (utils/format-effort effort analysis-type))]]]))
 
 (defn actions-table-view
   [current-scenario]
@@ -498,7 +495,7 @@
         providers-from-changeset (subscribe [:scenarios/providers-from-changeset])
         demand-unit              (get-demand-unit @current-project)
         capacity-unit            (get-capacity-unit @current-project)]
-    [:div.actions-table-view
+    [:<>
      [scenario-line-info current-scenario]
      [changeset/table-component {:demand-unit demand-unit
                                  :capacity-unit capacity-unit

--- a/client/src/planwise/client/ui/macros.clj
+++ b/client/src/planwise/client/ui/macros.clj
@@ -30,6 +30,7 @@
     GridTileTitle
     Icon
     List
+    ListDivider
     ListItem
     ListItemGraphic
     ListItemMeta

--- a/client/src/planwise/client/views.cljs
+++ b/client/src/planwise/client/views.cljs
@@ -51,6 +51,6 @@
 (defn planwise-app []
   (let [current-page (subscribe [:current-page])]
     (fn []
-      [:div
+      [:<>
        [content-pane @current-page]
        [intercom]])))

--- a/src/planwise/endpoint/home.clj
+++ b/src/planwise/endpoint/home.clj
@@ -17,8 +17,9 @@
 
 (def mount-target2
   [:div#app
-   [:h3 "Loading Application"]
-   [:p "Please wait..."]])
+   [:div.loading-wrapper
+    [:h3 "Loading Application"]
+    [:p "Please wait..."]]])
 
 (defn head2 []
   [:head


### PR DESCRIPTION
Closes #677 

- Move all scenario actions and downloads under the 3-dot menu
- Remove the FAB, the scenario title and the gear
- Bonus: fix the map taking taking more height than the available screen space and introducing a scrollbar
- Bonus: make the expanded sidebar table scroll instead of extending beyond the screen height
- Bonus: center the initial loading legend for the app
- Bonus: on the scenario view, fix highlighting the active section at the top

![Screenshot from 2021-12-01 10-37-05](https://user-images.githubusercontent.com/733591/144245534-233ac5f2-eee6-4fb7-aad1-e54ebcc04457.png)
![Screenshot from 2021-12-01 10-37-34](https://user-images.githubusercontent.com/733591/144245552-edcf05d3-ff50-4fb8-a0a3-af5e018acf27.png)
![Screenshot from 2021-12-01 10-37-20](https://user-images.githubusercontent.com/733591/144245549-cc0a76de-6fbe-468a-875c-6a73ffc291d0.png)
