### PR TITLE
Improved UX for new scenarios

### DIFF
--- a/client/resources/sass/site2.scss
+++ b/client/resources/sass/site2.scss
@@ -511,6 +511,21 @@ form.vertical, .fields-vertical {
       margin-right: 1rem;
     }
   }
+
+  .expand-center {
+    flex: 1;
+    display: flex;
+    justify-content: end;
+    flex-direction: column;
+    p {
+      font-size: 16px;
+      line-height: 1.5;
+      color: #999;
+    }
+  }
+  .actions {
+    margin-top: 10px;
+  }
 }
 
 .icon-list {

--- a/client/resources/sass/site2.scss
+++ b/client/resources/sass/site2.scss
@@ -633,28 +633,18 @@ form.vertical, .fields-vertical {
     // Scenarios table
 
     .col-state {
-      width: 15%;
+      width: 10%;
       text-align: left;
     }
 
     .col-name {
-      width: 10%;
+      width: 15%;
       text-align: left;
     }
 
     .col-demand-coverage {
       width: 15%;
       text-align: right;
-    }
-
-    .col-effort {
-      width: 10%;
-      text-align: right;
-    }
-
-    .col-actions {
-      text-align: left;
-      width: 20%;
     }
 
     .col-pop-without-service {
@@ -665,6 +655,17 @@ form.vertical, .fields-vertical {
     .col-pop-without-coverage {
       text-align: right;
       width: 15%;
+    }
+
+    .col-effort {
+      width: 10%;
+      text-align: right;
+      white-space: nowrap;
+    }
+
+    .col-actions {
+      text-align: left;
+      width: 20%;
     }
 
     .has-tooltip {
@@ -686,7 +687,7 @@ form.vertical, .fields-vertical {
     .has-tooltip:hover .tooltip {
       display: block;
       position: absolute;
-      width: 160px;
+      width: 200px;
       padding: 8px;
       background-color: #000;
       color: #ccc;

--- a/client/src/leaflet/controls.cljs
+++ b/client/src/leaflet/controls.cljs
@@ -14,15 +14,17 @@
   (new MapboxLogo (clj->js (merge {:position "topright"} options))))
 
 (defn- reference-table-content
-  []
+  [{:keys [hide-actions?] :as options}]
   (crate/html
    [:div.map-reference-table
-    [:h1 "Actions"]
-    [:ul
-     [:li [:i.material-icons "domain"] "New provider"]
-     [:li [:i.material-icons "arrow_upward"] "Upgrade provider"]
-     [:li [:i.material-icons "add"] "Increase capacity"]]
-    [:hr]
+    (when-not hide-actions?
+      [:div
+       [:h1 "Actions"]
+       [:ul
+        [:li [:i.material-icons "domain"] "New provider"]
+        [:li [:i.material-icons "arrow_upward"] "Upgrade provider"]
+        [:li [:i.material-icons "add"] "Increase capacity"]]
+       [:hr]])
     [:h1 "Provider capacity"]
     [:ul
      [:li [:div.leaflet-circle-icon.idle-capacity] "Excess"]
@@ -38,7 +40,9 @@
 
 (def ^:private ReferenceTable
   (js/L.Control.extend
-   #js {:onAdd (fn [] (reference-table-content))}))
+   #js {:onAdd (fn []
+                 (let [options (js->clj (.-options (js-this)) :keywordize-keys true)]
+                   (reference-table-content options)))}))
 
 (defn- reference-table
   [options]

--- a/client/src/planwise/client/projects2/components/dashboard.cljs
+++ b/client/src/planwise/client/projects2/components/dashboard.cljs
@@ -143,8 +143,7 @@
          "Without coverage"]
         [scenarios-sortable-header {:class [:col-effort]
                                     :align :right
-                                    :sorting-key :effort
-                                    :tooltip effort-label}
+                                    :sorting-key :effort}
          effort-label]
         [:th.col-actions [:p "Actions"]]]]
       [:tbody

--- a/client/src/planwise/client/scenarios/db.cljs
+++ b/client/src/planwise/client/scenarios/db.cljs
@@ -36,6 +36,10 @@
    :sort-order          nil
    :providers-search    nil})
 
+(defn initial-scenario?
+  [scenario]
+  (= (:label scenario) "initial"))
+
 (defmulti new-action :action-name)
 
 (defmethod new-action :create

--- a/client/src/planwise/client/scenarios/handlers.cljs
+++ b/client/src/planwise/client/scenarios/handlers.cljs
@@ -200,8 +200,14 @@
  (fn [{:keys [db]} [_]]
    (let [id (get-in db [:current-scenario :id])]
      {:api      (assoc (api/delete-scenario id)
-                       :on-success [:projects2/project-scenarios])
-      :dispatch [:scenarios/load-scenarios]})))
+                       :on-success [:scenarios/scenario-deleted])})))
+
+(rf/reg-event-fx
+ :scenarios/scenario-deleted
+ in-scenarios
+ (fn [{:keys [db]} _]
+   {:dispatch-n [[:scenarios/load-scenarios]
+                 [:projects2/project-scenarios]]}))
 
 
 ;;; Scenario action editing (changesets)

--- a/client/src/planwise/client/scenarios/subs.cljs
+++ b/client/src/planwise/client/scenarios/subs.cljs
@@ -5,9 +5,20 @@
             [cljs.reader :as edn]))
 
 (rf/reg-sub
+ :scenarios/list
+ (fn [db _]
+   (get-in db [:scenarios :list])))
+
+(rf/reg-sub
  :scenarios/current-scenario
  (fn [db _]
    (get-in db [:scenarios :current-scenario])))
+
+(rf/reg-sub
+ :scenarios/initial-scenario?
+ :<- [:scenarios/current-scenario]
+ (fn [current-scenario [_]]
+   (db/initial-scenario? current-scenario)))
 
 (rf/reg-sub
  :scenarios/view-state
@@ -23,8 +34,10 @@
 (rf/reg-sub
  :scenarios/can-expand-sidebar?
  :<- [:scenarios/view-state]
- (fn [view-state]
-   (#{:current-scenario :show-actions-table} view-state)))
+ :<- [:scenarios/initial-scenario?]
+ (fn [[view-state initial-scenario?]]
+   (and (not initial-scenario?)
+        (#{:current-scenario :show-actions-table} view-state))))
 
 (rf/reg-sub
  :scenarios/open-dialog
@@ -64,16 +77,6 @@
  :<- [:scenarios/open-dialog]
  (fn [open-dialog]
    (= :scenario-changeset open-dialog)))
-
-(rf/reg-sub
- :scenarios/list
- (fn [db _]
-   (get-in db [:scenarios :list])))
-
-(rf/reg-sub
- :scenarios/read-only? :<- [:scenarios/current-scenario]
- (fn [current-scenario [_]]
-   (= (:label current-scenario) "initial")))
 
 (rf/reg-sub
  :scenarios.map/selected-provider

--- a/client/src/planwise/client/utils.cljs
+++ b/client/src/planwise/client/utils.cljs
@@ -67,7 +67,7 @@
 
 (defn format-currency
   [value]
-  (str common/currency-symbol " " (format-number value)))
+  (str common/currency-symbol (format-number value)))
 
 (defn format-effort
   [effort analysis-type]

--- a/src/planwise/boundary/scenarios.clj
+++ b/src/planwise/boundary/scenarios.clj
@@ -18,8 +18,8 @@
   (update-scenario [this project props]
     "Updates the given scenario. Deferred computation will occur.")
 
-  (next-scenario-name [this project-id name]
-    "Returns a name for the following scenario to be created based on name")
+  (next-scenario-name [this scenario]
+    "Returns a name for a scenario to be created based on another one")
 
   (reset-scenarios [this project-id]
     "Reset scenarios information of project and clear engine state")

--- a/src/planwise/endpoint/scenarios.clj
+++ b/src/planwise/endpoint/scenarios.clj
@@ -1,5 +1,6 @@
 (ns planwise.endpoint.scenarios
   (:require [compojure.core :refer :all]
+            [compojure.coercions :refer [as-int]]
             [integrant.core :as ig]
             [taoensso.timbre :as timbre]
             [clojure.spec.alpha :as s]
@@ -7,126 +8,97 @@
             [planwise.util.ring :as util]
             [buddy.auth :refer [authenticated?]]
             [buddy.auth.accessrules :refer [restrict]]
-            [clojure.core.reducers :as r]
             [planwise.engine.common :as common]
             [planwise.boundary.scenarios :as scenarios]
             [planwise.boundary.projects2 :as projects2]))
 
 (timbre/refer-timbre)
 
-(defn- filter-owned-by
-  [project owner-id]
-  (when (= (:owner-id project) owner-id) project))
+(defn- scenario-export-prefix
+  [{:keys [id project-id name]}]
+  (str project-id "-" id "-" name))
 
-(defn- scenarios-routes
-  [{service :scenarios projects2 :projects2}]
-  [service]
+(defn- scenario-routes
+  [{service :scenarios}]
   (routes
-   (GET "/:id" [id :as request]
-     (let [user-id  (util/request-user-id request)
-           id       (Integer. id)
-           {:keys [project-id] :as scenario} (scenarios/get-scenario service id)
-           project  (filter-owned-by (projects2/get-project projects2 project-id) user-id)]
-       (if (or (nil? project) (nil? scenario))
-         (not-found {:error "Scenario not found"})
-         (response (scenarios/get-scenario-for-project service scenario project)))))
+   (GET "/" {:keys [scenario project]}
+     (response (scenarios/get-scenario-for-project service scenario project)))
 
-   (GET "/:id/providers" [id :as request]
-     (let [user-id  (util/request-user-id request)
-           id       (Integer. id)
-           {:keys [project-id] :as scenario} (scenarios/get-scenario service id)
-           project  (filter-owned-by (projects2/get-project projects2 project-id) user-id)
-           csv-name (str project-id "-" id "-" (:name scenario) ".providers.csv")
+   (PUT "/" [id :<< as-int scenario :as {:keys [project]}]
+     (let [scenario (assoc scenario :id id)]
+       (scenarios/update-scenario service project scenario)
+       (response (dissoc (scenarios/get-scenario service id) scenario :updated-at))))
+
+   (DELETE "/" [id :<< as-int]
+     (try
+       (scenarios/delete-scenario service id)
+       {:status 204}
+       (catch Exception e
+         {:status 400})))
+
+   (POST "/copy" {:keys [scenario project]}
+     (let [{:keys [project-id name changeset]} scenario
+
+           next-name    (scenarios/next-scenario-name service project-id name)
+           new-scenario (scenarios/create-scenario service project {:name      next-name
+                                                                    :changeset changeset})]
+       (response new-scenario)))
+
+   (GET "/providers" {:keys [scenario project]}
+     (let [csv-name (str (scenario-export-prefix scenario) ".providers.csv")
            csv-data (scenarios/export-providers-data service project scenario)]
        (-> (response csv-data)
            (content-type "text/csv")
            (header "Content-Disposition" (str "attachment; filename=" csv-name)))))
 
-   (GET "/:id/sources" [id :as request]
-     (let [user-id  (util/request-user-id request)
-           id       (Integer. id)
-           {:keys [project-id] :as scenario} (scenarios/get-scenario service id)
-           project  (filter-owned-by (projects2/get-project projects2 project-id) user-id)]
-       (if (or (nil? project) (nil? scenario))
-         (not-found {:error "Scenario not found"})
-         (if (common/is-project-raster? project)
-           (let [tif-name (str project-id "-" id "-" (:name scenario) ".source.tif")
-                 tif-file (common/scenario-raster-full-path (:raster scenario))]
-             (-> (file-response tif-file)
-                 (content-type "image/tiff")
-                 (header "Content-Disposition" (str "attachment; filename=" tif-name))))
-           (let [csv-name (str project-id "-" id "-" (:name scenario) ".sources.csv")
-                 csv-data (scenarios/export-sources-data service project scenario)]
-             (-> (response csv-data)
-                 (content-type "text/csv")
-                 (header "Content-Disposition" (str "attachment; filename=" csv-name))))))))
+   (GET "/sources" {:keys [scenario project]}
+     (if (common/is-project-raster? project)
+       (let [tif-name (str (scenario-export-prefix scenario) ".source.tif")
+             tif-file (common/scenario-raster-full-path (:raster scenario))]
+         (-> (file-response tif-file)
+             (content-type "image/tiff")
+             (header "Content-Disposition" (str "attachment; filename=" tif-name))))
+       (let [csv-name (str (scenario-export-prefix scenario) ".sources.csv")
+             csv-data (scenarios/export-sources-data service project scenario)]
+         (-> (response csv-data)
+             (content-type "text/csv")
+             (header "Content-Disposition" (str "attachment; filename=" csv-name))))))
 
-   (GET "/:id/suggested-locations" [id :as request]
-     (let [user-id  (util/request-user-id request)
-           id       (Integer. id)
-           {:keys [project-id] :as scenario} (scenarios/get-scenario service id)
-           project  (filter-owned-by (projects2/get-project projects2 project-id) user-id)
-           result   (scenarios/get-suggestions-for-new-provider-location service project scenario)]
+   (GET "/suggested-locations" {:keys [scenario project]}
+     (let [result (scenarios/get-suggestions-for-new-provider-location service project scenario)]
        (if (empty? result)
          (not-found {:error "Can not find optimal locations"})
          (response result))))
 
-   (GET "/:id/suggested-providers" [id :as request]
-     (let [user-id  (util/request-user-id request)
-           id       (Integer. id)
-           {:keys [project-id] :as scenario} (scenarios/get-scenario service id)
-           project  (filter-owned-by (projects2/get-project projects2 project-id) user-id)
-           result   (scenarios/get-suggestions-for-improving-providers service project scenario)]
+   (GET "/suggested-providers" {:keys [scenario project]}
+     (let [result (scenarios/get-suggestions-for-improving-providers service project scenario)]
        (if (empty? result)
          (not-found {:error "Can not find optimal improvements"})
          (response result))))
 
-   (GET "/:id/geometry/:provider-id" [id provider-id :as request]
-     (let [user-id  (util/request-user-id request)
-           id       (Integer. id)
-           {:keys [project-id] :as scenario} (scenarios/get-scenario service id)
-           project  (filter-owned-by (projects2/get-project projects2 project-id) user-id)
-           geometry (scenarios/get-provider-geom service project scenario provider-id)]
-       (response geometry)))
+   (GET "/geometry/:provider-id" [provider-id :as {:keys [scenario project]}]
+     (if-let [geometry (scenarios/get-provider-geom service project scenario provider-id)]
+       (response geometry)
+       (not-found {:error "Provider coverage not found"})))))
 
-   (PUT "/:id" [id scenario :as request]
-     (let [user-id    (util/request-user-id request)
-           id         (Integer. id)
-           scenario   (assoc scenario :id id)
-           project-id (:project-id (scenarios/get-scenario service id))
-           project    (filter-owned-by (projects2/get-project projects2 project-id) user-id)]
-       (if (or (nil? project) (nil? scenario))
-         (not-found {:error "Scenario not found"})
-         (do
-           (scenarios/update-scenario service project scenario)
-           (response (dissoc (scenarios/get-scenario service id) scenario :updated-at))))))
-
-   (POST "/:id/copy" [id :as request]
-     (let [user-id    (util/request-user-id request)
-           id         (Integer. id)
-           scenario   (scenarios/get-scenario service id)
-           project-id (:project-id scenario)
-           project    (filter-owned-by (projects2/get-project projects2 project-id) user-id)
-           {:keys [name changeset]} scenario
-           next-name  (scenarios/next-scenario-name service project-id name)]
-       (if (or (nil? project) (nil? scenario))
-         (not-found {:error "Scenario not found"})
-         (response (scenarios/create-scenario service project {:name next-name
-                                                               :changeset changeset})))))
-
-   (DELETE "/:id" [id :as request]
-     (let [user-id           (util/request-user-id request)
-           scenario-id       (Integer. id)]
-       (try
-         (scenarios/delete-scenario service scenario-id)
-         {:status 204}
-         (catch Exception e
-           {:status 400}))))))
+(defn- wrap-fetch-scenario
+  [handler {:keys [scenarios projects2]}]
+  (fn [request]
+    (let [user-id  (util/request-user-id request)
+          id       (-> request :params :id as-int)
+          scenario (scenarios/get-scenario scenarios id)
+          project  (projects2/get-project projects2 (:project-id scenario))]
+      (if (or (nil? project) (nil? scenario) (not= user-id (:owner-id project)))
+        (not-found {:error "Scenario not found"})
+        (handler (merge request {:scenario scenario
+                                 :project  project}))))))
 
 (defn scenarios-endpoint
   [config]
-  (context "/api/scenarios" []
-    (restrict (scenarios-routes config) {:handler authenticated?})))
+  (context "/api/scenarios/:id" []
+    (-> (scenario-routes config)
+        (wrap-fetch-scenario config)
+        (restrict {:handler authenticated?}))))
 
 (defmethod ig/init-key :planwise.endpoint/scenarios
   [_ config]

--- a/src/planwise/endpoint/scenarios.clj
+++ b/src/planwise/endpoint/scenarios.clj
@@ -37,9 +37,9 @@
          {:status 400})))
 
    (POST "/copy" {:keys [scenario project]}
-     (let [{:keys [project-id name changeset]} scenario
+     (let [{:keys [changeset]} scenario
 
-           next-name    (scenarios/next-scenario-name service project-id name)
+           next-name    (scenarios/next-scenario-name service scenario)
            new-scenario (scenarios/create-scenario service project {:name      next-name
                                                                     :changeset changeset})]
        (response new-scenario)))

--- a/src/planwise/model/scenarios.clj
+++ b/src/planwise/model/scenarios.clj
@@ -1,5 +1,9 @@
 (ns planwise.model.scenarios
-  (:require [clojure.spec.alpha :as s]))
+  (:require [clojure.spec.alpha :as s]
+            [clojure.string :as str]))
+
+
+;;; Specs
 
 (s/def ::investment int?)
 (s/def ::capacity int?)
@@ -33,3 +37,75 @@
 
 (s/def ::change-set
   (s/coll-of ::change))
+
+
+;;; Scenario predicates
+
+(defn is-initial-scenario?
+  [scenario]
+  (= "initial" (:label scenario)))
+
+
+;;; Naming scenario copies
+
+(defn- default-scenario-suffixes
+  "Extract scenario name suffixes for default names"
+  [existing-names]
+  (->> existing-names
+       (map #(when-let [[_ suffix] (re-find #"^Scenario ([A-Z].*|[0-9]+)" %)] suffix))
+       (filter some?)))
+
+(defn- next-alpha-suffix
+  "Given a list of suffixes, find the next capital letter after the last
+  present. If 'Z...' already exists, returns nil."
+  [suffixes]
+  (if-let [alpha-suffix (->> suffixes
+                             (filter #(re-find #"^[A-Z]" %))
+                             sort
+                             last)]
+    (let [first-letter (first alpha-suffix)
+          next-letter  (char (min (int \Z) (-> first-letter int inc)))]
+      (when-not (= next-letter first-letter)
+        next-letter))
+    "A"))
+
+(defn- next-numeric-suffix
+  "Given a list of suffixes, computes the next integer after the biggest number present."
+  [suffixes]
+  (if-let [numeric-suffix (->> suffixes
+                               (filter #(re-matches #"^[0-9]+" %))
+                               (map #(Integer/parseInt %))
+                               sort
+                               last)]
+    (str (inc numeric-suffix))
+    "1"))
+
+(defn next-name-from-initial
+  [existing-names]
+  (let [suffixes    (default-scenario-suffixes existing-names)
+        next-suffix (or (next-alpha-suffix suffixes)
+                        (next-numeric-suffix suffixes))]
+    (str "Scenario " next-suffix)))
+
+(defn- prefix-and-copy-number
+  [name]
+  (if-let [[_ prefix copy-number] (re-matches #"^(.*)\s*\(([0-9]+)\)$" name)]
+    [(str/trimr prefix) (some-> copy-number Integer/parseInt)]
+    [(str/trimr name) 0]))
+
+(defn- find-latest-copy
+  [existing-names prefix]
+  (or (->> existing-names
+           (map prefix-and-copy-number)
+           (filter #(= prefix (first %)))
+           (map second)
+           sort
+           max
+           last)
+      0))
+
+(defn next-name-for-copy
+  [existing-names original]
+  (let [[prefix copy-number] (prefix-and-copy-number original)
+        latest-copy          (find-latest-copy existing-names prefix)]
+    (str prefix " (" (inc (max copy-number latest-copy)) ")")))

--- a/test/planwise/model/scenarios_test.clj
+++ b/test/planwise/model/scenarios_test.clj
@@ -1,0 +1,24 @@
+(ns planwise.model.scenarios-test
+  (:require [planwise.model.scenarios :as sut]
+            [clojure.test :refer :all]))
+
+
+(deftest test-next-name-from-initial
+  (is (= "Scenario A" (sut/next-name-from-initial ["Initial"])))
+  (is (= "Scenario A" (sut/next-name-from-initial ["Initial" "Scenario" "Other Name"])))
+  (is (= "Scenario A" (sut/next-name-from-initial ["Initial" "Scenario 1"])))
+  (is (= "Scenario B" (sut/next-name-from-initial ["Initial" "Scenario A"])))
+  (is (= "Scenario C" (sut/next-name-from-initial ["Initial" "Scenario B"])))
+  (is (= "Scenario Z" (sut/next-name-from-initial ["Initial" "Scenario Y"])))
+  (is (= "Scenario 1" (sut/next-name-from-initial ["Initial" "Scenario Z"])))
+  (is (= "Scenario 2" (sut/next-name-from-initial ["Initial" "Scenario Z" "Scenario 1"])))
+  (is (= "Scenario 43" (sut/next-name-from-initial ["Initial" "Scenario Z" "Scenario 42"]))))
+
+(deftest test-next-name-for-copy
+  (is (= "Foo (1)" (sut/next-name-for-copy ["Foo"] "Foo")))
+  (is (= "Foo (1)" (sut/next-name-for-copy ["Foo" "Bar (1)"] "Foo")))
+  (is (= "Foo (1)" (sut/next-name-for-copy ["Foo" "Foo2 (1)"] "Foo")))
+  (is (= "Foo (2)" (sut/next-name-for-copy ["Foo" "Foo (1)"] "Foo")))
+  (is (= "Foo (2)" (sut/next-name-for-copy ["Foo" "Foo(1)"] "Foo")))
+  (is (= "Foo (2)" (sut/next-name-for-copy ["Foo" "Foo (1)"] "Foo (1)")))
+  (is (= "Foo (3)" (sut/next-name-for-copy ["Foo (2)"] "Foo"))))


### PR DESCRIPTION
Closes #696 

- In the initial scenario, hide the 3-dot options menu with actions for the scenario (most of them do not make sense for the initial scenario)
- Add a legend and a button to create a new scenario in the sidebar
- Hide the "Changes" part of the map legend in the initial scenario
- Improve the naming of newly created scenarios:
  - Copies from the initial scenario are named "Scenario A", "Scenario B" and so on.
  - Use numbers instead if "Scenario Z" already exists, ie. "Scenario 1", "Scenario 2", etc.
  - Copies of other scenarios have a copy number suffix added, ie. "Foo" -> "Foo (1)" and "Foo (3)" -> "Foo (4)"
- Bonus: refactor to reduce duplication in scenario endpoint code

![Screenshot from 2021-12-09 17-57-06](https://user-images.githubusercontent.com/733591/145475040-192b4398-066d-4e34-a19a-cde8cae77528.png)
