### PR TITLE
Improve UX when listing suggestions

### DIFF
--- a/client/resources/sass/site2.scss
+++ b/client/resources/sass/site2.scss
@@ -1333,9 +1333,12 @@ form.vertical, .fields-vertical {
   &.small-unsatisfied, &.mid-unsatisfied, &.unsatisfied {
     background-color: #ff5722;
   }
-
   &.upgradeable {
     background-color: #999;
+  }
+  &.disabled {
+    cursor: default;
+    opacity: 0.3;
   }
   &.selected[style] {
     width: 24px !important;

--- a/client/resources/sass/site2.scss
+++ b/client/resources/sass/site2.scss
@@ -1151,11 +1151,12 @@ form.vertical, .fields-vertical {
   color: black;
   border: 3px solid darkcyan !important;
   background: cyan;
+  box-sizing: border-box;
   &[style] {
-    width: 16px !important;
-    height: 16px !important;
-    margin-top: -8px !important;
-    margin-left: -8px !important;
+    width: 22px !important;
+    height: 22px !important;
+    margin-top: -11px !important;
+    margin-left: -11px !important;
   }
   > span {
     z-index: 1;

--- a/client/src/planwise/client/scenarios/api.cljs
+++ b/client/src/planwise/client/scenarios/api.cljs
@@ -1,42 +1,47 @@
 (ns planwise.client.scenarios.api)
 
-(defn- load-scenario
+(defn load-scenario
   [id]
   {:method    :get
    :uri       (str "/api/scenarios/" id)})
 
-(defn- copy-scenario
+(defn copy-scenario
   [id]
   {:method    :post
    :uri       (str "/api/scenarios/" id "/copy")})
 
-(defn- update-scenario
+(defn update-scenario
   [id scenario]
   {:method    :put
    :params    {:scenario scenario}
    :uri       (str "/api/scenarios/" id)})
 
-(defn- load-scenarios
+(defn load-scenarios
   [id]
   {:method    :get
    :uri       (str "/api/projects2/" id "/scenarios")})
 
-(defn- suggested-locations-for-new-provider
+(defn suggested-locations-for-new-provider
   [id]
   {:method    :get
    :timeout   90000
    :uri       (str "/api/scenarios/" id "/suggested-locations")})
 
-(defn- suggested-providers-to-improve
+(defn suggested-providers-to-improve
   [id]
   {:method    :get
    :timeout   90000
    :uri       (str "/api/scenarios/" id "/suggested-providers")})
 
-(defn- get-provider-geom
+(defn get-provider-geom
   [id provider-id]
   {:method :get
    :uri    (str "/api/scenarios/" id "/geometry/" provider-id)})
+
+(defn get-suggestion-geom
+  [id iteration]
+  {:method :get
+   :uri    (str "/api/scenarios/" id "/coverage/suggestion/" iteration)})
 
 (defn- delete-scenario
   [id]

--- a/client/src/planwise/client/scenarios/changeset.cljs
+++ b/client/src/planwise/client/scenarios/changeset.cljs
@@ -70,7 +70,7 @@
        :on-click      #(dispatch [:scenarios/edit-suggestion suggestion])
        :class         (when (= suggestion selected-suggestion) "selected")}
       [:div.icon-list
-       [m/Icon {} (get action-icons "create-provider")]
+       [m/Icon {} (get action-icons (get-in suggestion [:change :action]))]
        [:div.icon-list-text
         [:p.strong (or name (str "Suggestion " ranked))]
         [:p.grey-text (str "Required Capacity: "
@@ -83,7 +83,8 @@
 (defn suggestion-listing-component
   [props suggestions]
   [:div.suggestion-list
-   (map (fn [suggestion] [suggestion-row (merge props {:key (str (:name suggestion) (:ranked suggestion))}) suggestion])
+   (map (fn [suggestion]
+          [suggestion-row (merge props {:key (or (:id suggestion) (:ranked suggestion))}) suggestion])
         suggestions)])
 
 (defn- changeset-table-row

--- a/client/src/planwise/client/scenarios/changeset.cljs
+++ b/client/src/planwise/client/scenarios/changeset.cljs
@@ -70,7 +70,7 @@
        :on-click      #(dispatch [:scenarios/edit-suggestion suggestion])
        :class         (when (= suggestion selected-suggestion) "selected")}
       [:div.icon-list
-       [m/Icon {} (get action-icons (get-in suggestion [:change :action]))]
+       [m/Icon (get action-icons (get-in suggestion [:change :action] "create-provider"))]
        [:div.icon-list-text
         [:p.strong (or name (str "Suggestion " ranked))]
         [:p.grey-text (str "Required Capacity: "

--- a/client/src/planwise/client/scenarios/changeset.cljs
+++ b/client/src/planwise/client/scenarios/changeset.cljs
@@ -36,7 +36,7 @@
   [{:keys [change] :as provider}]
   [m/Icon (get action-icons (:action change) "domain")])
 
-(defn- changeset-row
+(defn- provider-row
   [props {:keys [name change matches-filters] :as provider}]
   (let [action            (:action change)
         selected-provider @(subscribe [:scenarios.map/selected-provider])]
@@ -44,7 +44,9 @@
      [:div.section.changeset-row
       {:on-mouse-over  #(dispatch [:scenarios.map/select-provider (assoc provider :hover? true)])
        :on-mouse-leave #(dispatch [:scenarios.map/unselect-provider provider])
-       :on-click       #(dispatch [:scenarios/open-changeset-dialog provider])
+       :on-click       (if (some? change)
+                         #(dispatch [:scenarios/edit-change-in-dialog provider])
+                         #(dispatch [:scenarios/create-change-in-dialog provider :keep-state]))
        :class          [(when (= (:id selected-provider) (:id provider)) "selected")
                         (when (and (nil? action) (false? matches-filters)) "upgradeable")]}
       [:div.icon-list
@@ -57,7 +59,7 @@
 (defn listing-component
   [props providers]
   [:div.scroll-list
-   (map (fn [provider] [changeset-row (merge props {:key (:id provider)}) provider])
+   (map (fn [provider] [provider-row (merge props {:key (:id provider)}) provider])
         providers)])
 
 (defn- suggestion-row

--- a/client/src/planwise/client/scenarios/db.cljs
+++ b/client/src/planwise/client/scenarios/db.cljs
@@ -35,6 +35,7 @@
    :sort-column         nil
    :sort-order          nil
    :suggestions         {:request-key  nil
+                         :coverages    nil
                          :locations    nil
                          :improvements nil}
    :providers-search    nil})

--- a/client/src/planwise/client/scenarios/db.cljs
+++ b/client/src/planwise/client/scenarios/db.cljs
@@ -18,7 +18,7 @@
 ;;                           │  │  :new-intervention
 ;;                           │  │        ▲
 ;;                           ▼  │        │
-;;                 :get-sugggestions-for-improvements
+;;                 :get-suggestions-for-improvements
 
 
 (def initial-db
@@ -34,6 +34,9 @@
    :list                (asdf/new nil)
    :sort-column         nil
    :sort-order          nil
+   :suggestions         {:request-key  nil
+                         :locations    nil
+                         :improvements nil}
    :providers-search    nil})
 
 (defn initial-scenario?
@@ -72,6 +75,12 @@
    :location        (:location change)
    :matches-filters true
    :change          change})
+
+(defn provider-with-change
+  [{:keys [change matches-filters] :as provider}]
+  (let [change' (or change
+                    (new-action provider (if (not matches-filters) :upgrade :increase)))]
+    (assoc provider :change change')))
 
 (defn- apply-change
   [providers-by-id change]

--- a/client/src/planwise/client/scenarios/db.cljs
+++ b/client/src/planwise/client/scenarios/db.cljs
@@ -27,6 +27,7 @@
    :rename-dialog       nil
    :current-scenario    nil
    :changeset-dialog    {:provider     nil
+                         :new-change?  false
                          :reset-state? false}
    :selected-provider   nil
    :selected-suggestion nil

--- a/client/src/planwise/client/scenarios/db.cljs
+++ b/client/src/planwise/client/scenarios/db.cljs
@@ -26,7 +26,8 @@
    :open-dialog         nil
    :rename-dialog       nil
    :current-scenario    nil
-   :changeset-dialog    nil
+   :changeset-dialog    {:provider     nil
+                         :reset-state? false}
    :selected-provider   nil
    :selected-suggestion nil
    :coverage-cache      nil

--- a/client/src/planwise/client/scenarios/edit.cljs
+++ b/client/src/planwise/client/scenarios/edit.cljs
@@ -238,4 +238,4 @@
           [m/MenuItem
            {:on-click (close-and-dispatch [:scenarios.new-action/fetch-suggested-providers-to-improve])}
            [m/ListItemGraphic "arrow_upward"]
-           (str "Suggest " provider-unit " to increase capacity")]]]))))
+           (str "Suggest " provider-unit " to improve")]]]))))

--- a/client/src/planwise/client/scenarios/edit.cljs
+++ b/client/src/planwise/client/scenarios/edit.cljs
@@ -85,60 +85,79 @@
   (and (= (:action change) "create-provider") (nil? free-capacity)))
 
 (defn changeset-dialog-content
-  [{:keys [name initial-capacity capacity required-capacity free-capacity available-budget change] :as provider} {:keys [budget? demand-unit capacity-unit] :as props}]
-  (let [new?      (new-provider? provider)
-        increase? (= (:action change) "increase-provider")
-        create?   (= (:action change) "create-provider")
-        idle?     (pos? free-capacity)]
+  [{:keys [name initial-capacity capacity required-capacity free-capacity available-budget change]
+    :as   provider}
+   {:keys [budget? demand-unit capacity-unit]
+    :as   props}]
+  (let [new?             (new-provider? provider)
+        increase?        (= (:action change) "increase-provider")
+        create?          (= (:action change) "create-provider")
+        idle?            (pos? free-capacity)
+        update-change-fn (fn [field value]
+                           (dispatch [:scenarios/save-key [:changeset-dialog :provider :change field] value]))]
     [:div
      ;; Allow name change when creating a new provider
      [common2/text-field (merge {:label "Name"
                                  :value (if create? (:name change) name)}
                                 (if create?
-                                  {:on-change #(dispatch [:scenarios/save-key [:changeset-dialog :change :name] (-> % .-target .-value)])}
-                                  {:read-only true
+                                  {:on-change #(update-change-fn :name (-> % .-target .-value))}
+                                  {:on-change         #()
+                                   :read-only         true
                                    :focus-extra-class "show-static-text"}))]
      [:div
       (when increase?
-        [common2/text-field {:label (str "Current " capacity-unit)
+        [common2/text-field {:label     (str "Current " capacity-unit)
                              :read-only true
-                             :value initial-capacity}])
-      [common2/numeric-field {:label (if increase? (str (capitalize capacity-unit) " to add") (capitalize capacity-unit))
-                              :on-change  #(dispatch [:scenarios/save-key  [:changeset-dialog :change :capacity] %])
-                              :value (:capacity change)}]
+                             :value     initial-capacity}])
+      [common2/numeric-field {:label     (if increase?
+                                           (str (capitalize capacity-unit) " to add")
+                                           (capitalize capacity-unit))
+                              :on-change (partial update-change-fn :capacity)
+                              :value     (:capacity change)}]
+
       ;; Show unsatisfied demand when data is available from an existing provider or
       ;; when creating a provider from a suggestion
       (when (or (some? capacity) (some? required-capacity))
         (let [extra-capacity          (:capacity change)
               total-required-capacity (if idle? (- capacity free-capacity) (+ capacity required-capacity))
               required                (Math/ceil (- total-required-capacity initial-capacity extra-capacity))]
-          (cond (not (neg? required)) [:div.inline
-                                       [common2/text-field {:label (str "Required " capacity-unit)
-                                                            :read-only true
-                                                            :value (utils/format-number (Math/abs required))}]
-                                       [:p.text-helper (capitalize demand-unit) " without service: " (utils/format-number (* (:project-capacity props) (Math/abs required)))]]
-                (neg? required)       [common2/text-field {:label "Free capacity"
-                                                           :read-only true
-                                                           :value (utils/format-number (Math/abs required))}])))]
+          (cond
+            (not (neg? required))
+            [:div.inline
+             [common2/text-field {:label     (str "Required " capacity-unit)
+                                  :read-only true
+                                  :value     (utils/format-number (Math/abs required))}]
+             [:p.text-helper
+              (capitalize demand-unit)
+              " without service: "
+              (utils/format-number (* (:project-capacity props) (Math/abs required)))]]
+
+            (neg? required)
+            [common2/text-field {:label     "Free capacity"
+                                 :read-only true
+                                 :value     (utils/format-number (Math/abs required))}])))]
+
+     ;;; Budget control
      (if budget?
-       (let [remaining-budget           (- available-budget (:investment change))
-             suggested-cost             (suggest-investment change props)
-             show-suggested-cost        (or (configured-costs? props)
-                                            (:action-cost provider))]
+       (let [remaining-budget    (- available-budget (:investment change))
+             suggested-cost      (suggest-investment change props)
+             show-suggested-cost (or (configured-costs? props)
+                                     (:action-cost provider))]
          [:div
           [common2/numeric-field {:label         "Investment"
                                   :sub-type      :float
-                                  :on-change     #(dispatch [:scenarios/save-key [:changeset-dialog :change :investment] %])
+                                  :on-change     (partial update-change-fn :investment)
                                   :invalid-input (< available-budget (:investment change))
                                   :value         (:investment change)}]
-          [common2/numeric-field {:label         "Available budget"
-                                  :sub-type      :float
-                                  :read-only     true
-                                  :value        (if (pos? remaining-budget) remaining-budget 0)}]
+          [common2/numeric-field {:label     "Available budget"
+                                  :sub-type  :float
+                                  :read-only true
+                                  :value     (if (pos? remaining-budget) remaining-budget 0)}]
           (when show-suggested-cost
             [:p.text-helper
-             {:on-click #(dispatch [:scenarios/save-key [:changeset-dialog :change :investment] (min suggested-cost remaining-budget)])}
-             "Suggested investment according to project configuration: " (- suggested-cost (:investment change))])]))]))
+             {:on-click #(update-change-fn :investment (min suggested-cost remaining-budget))}
+             "Suggested investment according to project configuration: "
+             (- suggested-cost (:investment change))])]))]))
 
 (def action-labels
   {"create-provider" "Create"
@@ -151,23 +170,24 @@
 
 (defn changeset-dialog
   [project scenario]
-  (let [provider   (subscribe [:scenarios/changeset-dialog])
-        open?      (subscribe [:scenarios/changeset-dialog-open?])]
+  (let [dialog-data (subscribe [:scenarios/changeset-dialog])
+        open?       (subscribe [:scenarios/changeset-dialog-open?])]
     (fn [{:keys [config] :as project} scenario]
-      (let [action        (get-in @provider [:change :action])
+      (let [provider      (:provider @dialog-data)
+            action        (get-in provider [:change :action])
             budget        (get-in config [:actions :budget])
             budget?       (common/is-budget (get-in config [:analysis-type]))
-            new?          (new-provider? @provider)
+            new?          (new-provider? provider)
             demand-unit   (common/get-demand-unit project)
             capacity-unit (common/get-capacity-unit project)]
         (dialog (merge {:open?       @open?
                         :acceptable? (and (or (not budget?)
-                                              ((fnil pos? 0) (get-in @provider [:change :investment])))
-                                          ((fnil pos? 0) (get-in @provider [:change :capacity])))
+                                              ((fnil pos? 0) (get-in provider [:change :investment])))
+                                          ((fnil pos? 0) (get-in provider [:change :capacity])))
                         :title       (action->title action)
                         :content     (when @open?
                                        (changeset-dialog-content
-                                        (merge @provider
+                                        (merge provider
                                                (if budget?
                                                  {:available-budget (- budget (:effort scenario))}))
                                         {:project-capacity (get-in config [:providers :capacity])
@@ -180,7 +200,7 @@
                         :accept-fn   #(dispatch [:scenarios/accept-changeset-dialog])
                         :cancel-fn   #(dispatch [:scenarios/cancel-dialog])}
                        (when-not new?
-                         {:delete-fn #(dispatch [:scenarios/delete-change (:id @provider)])})))))))
+                         {:delete-fn #(dispatch [:scenarios/delete-change (:id provider)])})))))))
 
 
 ;;; "New" actions UI

--- a/client/src/planwise/client/scenarios/edit.cljs
+++ b/client/src/planwise/client/scenarios/edit.cljs
@@ -80,17 +80,12 @@
                              (seq (:increasing-costs props)))
     (seq (:building-costs props))))
 
-(defn new-provider?
-  [{:keys [change required-capacity free-capacity]}]
-  (and (= (:action change) "create-provider") (nil? free-capacity)))
-
 (defn changeset-dialog-content
   [{:keys [name initial-capacity capacity required-capacity free-capacity available-budget change]
     :as   provider}
    {:keys [budget? demand-unit capacity-unit]
     :as   props}]
-  (let [new?             (new-provider? provider)
-        increase?        (= (:action change) "increase-provider")
+  (let [increase?        (= (:action change) "increase-provider")
         create?          (= (:action change) "create-provider")
         idle?            (pos? free-capacity)
         update-change-fn (fn [field value]
@@ -174,10 +169,10 @@
         open?       (subscribe [:scenarios/changeset-dialog-open?])]
     (fn [{:keys [config] :as project} scenario]
       (let [provider      (:provider @dialog-data)
+            new-change?   (:new-change? @dialog-data)
             action        (get-in provider [:change :action])
             budget        (get-in config [:actions :budget])
             budget?       (common/is-budget (get-in config [:analysis-type]))
-            new?          (new-provider? provider)
             demand-unit   (common/get-demand-unit project)
             capacity-unit (common/get-capacity-unit project)]
         (dialog (merge {:open?       @open?
@@ -199,7 +194,7 @@
                                          :capacity-unit    capacity-unit}))
                         :accept-fn   #(dispatch [:scenarios/accept-changeset-dialog])
                         :cancel-fn   #(dispatch [:scenarios/cancel-dialog])}
-                       (when-not new?
+                       (when-not new-change?
                          {:delete-fn #(dispatch [:scenarios/delete-change (:id provider)])})))))))
 
 

--- a/client/src/planwise/client/scenarios/handlers.cljs
+++ b/client/src/planwise/client/scenarios/handlers.cljs
@@ -229,7 +229,7 @@
          new-name         (new-provider-name (:changeset current-scenario))
          new-action       (db/new-action {:location location
                                           :name     new-name}
-                                     :create)
+                                         :create)
          new-provider     (merge (db/new-provider-from-change new-action) suggestion)]
      {:dispatch [:scenarios/create-change-in-dialog new-provider]})))
 

--- a/client/src/planwise/client/scenarios/handlers.cljs
+++ b/client/src/planwise/client/scenarios/handlers.cljs
@@ -240,6 +240,7 @@
    (assoc db
           :open-dialog      :scenario-changeset
           :changeset-dialog {:provider     (db/provider-with-change provider)
+                             :new-change?  true
                              :reset-state? (not keep-state?)})))
 
 (rf/reg-event-db
@@ -249,6 +250,7 @@
    (assoc db
           :open-dialog      :scenario-changeset
           :changeset-dialog {:provider     provider
+                             :new-change?  false
                              :reset-state? false})))
 
 (rf/reg-event-fx

--- a/client/src/planwise/client/scenarios/subs.cljs
+++ b/client/src/planwise/client/scenarios/subs.cljs
@@ -81,13 +81,19 @@
 (rf/reg-sub
  :scenarios.map/selected-provider
  (fn [db _]
-   (when-let [provider (get-in db [:scenarios :selected-provider])]
-     (assoc provider :coverage-geom (get-in db [:scenarios :coverage-cache (:id provider)])))))
+   (get-in db [:scenarios :selected-provider])))
 
 (rf/reg-sub
  :scenarios.map/selected-suggestion
  (fn [db _]
    (get-in db [:scenarios :selected-suggestion])))
+
+(rf/reg-sub
+ :scenarios.map/selected-coverage
+ (fn [db _]
+   (when-let [coverage-id (:id (or (get-in db [:scenarios :selected-suggestion])
+                                   (get-in db [:scenarios :selected-provider])))]
+     (get-in db [:scenarios :coverage-cache coverage-id]))))
 
 (rf/reg-sub
  :scenarios/suggested-locations

--- a/client/src/planwise/client/scenarios/subs.cljs
+++ b/client/src/planwise/client/scenarios/subs.cljs
@@ -135,6 +135,12 @@
      nil)))
 
 (rf/reg-sub
+ :scenarios/listing-suggestions?
+ :<- [:scenarios/suggestions]
+ (fn [suggestions]
+   (seq suggestions)))
+
+(rf/reg-sub
  :scenarios/all-providers
  :<- [:scenarios/current-scenario]
  (fn [scenario _]

--- a/client/src/planwise/client/scenarios/subs.cljs
+++ b/client/src/planwise/client/scenarios/subs.cljs
@@ -91,9 +91,11 @@
 (rf/reg-sub
  :scenarios.map/selected-coverage
  (fn [db _]
-   (when-let [coverage-id (:id (or (get-in db [:scenarios :selected-suggestion])
-                                   (get-in db [:scenarios :selected-provider])))]
-     (get-in db [:scenarios :coverage-cache coverage-id]))))
+   (if-let [iteration (:iteration (get-in db [:scenarios :selected-suggestion]))]
+     (get-in db [:scenarios :suggestions :coverages iteration])
+     (when-let [coverage-id (:id (or (get-in db [:scenarios :selected-suggestion])
+                                     (get-in db [:scenarios :selected-provider])))]
+       (get-in db [:scenarios :coverage-cache coverage-id])))))
 
 (rf/reg-sub
  :scenarios/suggested-locations

--- a/client/src/planwise/client/scenarios/views.cljs
+++ b/client/src/planwise/client/scenarios/views.cljs
@@ -58,10 +58,7 @@
            free-capacity required-capacity
            satisfied-demand unsatisfied-demand reachable-demand]
     :as   provider}]
-  (let [format-number (fnil utils/format-number 0)
-        change*       (if (some? change)
-                        change
-                        (db/new-action provider (if (not matches-filters) :upgrade :increase)))]
+  (let [format-number (fnil utils/format-number 0)]
     (crate/html
      [:div.mdc-typography
       [:h3 name]
@@ -93,7 +90,9 @@
             (some? change)        "Edit"
             (not matches-filters) "Upgrade"
             :else                 "Increase")
-          #(dispatch [:scenarios/open-changeset-dialog (assoc provider :change change*)]))])])))
+          (if (some? change)
+            #(dispatch [:scenarios/edit-change-in-dialog provider])
+            #(dispatch [:scenarios/create-change-in-dialog provider])))])])))
 
 (defn- get-percentage
   [total relative]

--- a/src/planwise/boundary/scenarios.clj
+++ b/src/planwise/boundary/scenarios.clj
@@ -39,8 +39,11 @@
   (get-suggestions-for-new-provider-location [store project scenario]
     "Get list of locations suggested for creating new provider")
 
-  (get-provider-geom [store scenario project provider-id]
+  (get-provider-geom [store project scenario provider-id]
     "Retrieves provider coverage geometries")
+
+  (get-suggestion-geom [store project scenario iteration]
+    "Retrieves suggested location coverage for iteration")
 
   (delete-scenario [store scenario-id]
     "Delete scenario by id.

--- a/src/planwise/component/scenarios.clj
+++ b/src/planwise/component/scenarios.clj
@@ -156,6 +156,14 @@
     (when (:resolved query-result)
       {:coverage-geom (:geojson query-result)})))
 
+(defn get-suggestion-geom
+  [store project scenario iteration]
+  (let [context-id   [:suggestions (:id project) (:id scenario)]
+        query-id     [:iteration iteration]
+        query-result (first (coverage/query-coverages (:coverage store) context-id :geojson [query-id]))]
+    (when (:resolved query-result)
+      {:coverage-geom (:geojson query-result)})))
+
 (defn list-scenarios
   [store project]
   ;; TODO compute % coverage from initial scenario/project
@@ -468,8 +476,10 @@
     (export-sources-data store project scenario))
   (get-suggestions-for-new-provider-location [store project scenario]
     (get-suggestions-for-new-provider-location store project scenario))
-  (get-provider-geom [store scenario project provider-id]
-    (get-provider-geom store scenario project provider-id))
+  (get-provider-geom [store project scenario provider-id]
+    (get-provider-geom store project scenario provider-id))
+  (get-suggestion-geom [store project scenario iteration]
+    (get-suggestion-geom store project scenario iteration))
   (delete-scenario [store scenario-id]
     (delete-scenario store scenario-id))
   (get-suggestions-for-improving-providers [store project scenario]

--- a/src/planwise/endpoint/scenarios.clj
+++ b/src/planwise/endpoint/scenarios.clj
@@ -79,7 +79,12 @@
    (GET "/geometry/:provider-id" [provider-id :as {:keys [scenario project]}]
      (if-let [geometry (scenarios/get-provider-geom service project scenario provider-id)]
        (response geometry)
-       (not-found {:error "Provider coverage not found"})))))
+       (not-found {:error "Provider coverage not found"})))
+
+   (GET "/coverage/suggestion/:iteration" [iteration :<< as-int :as {:keys [scenario project]}]
+     (if-let [geometry (scenarios/get-suggestion-geom service project scenario iteration)]
+       (response geometry)
+       (not-found {:error "Coverage not found"})))))
 
 (defn- wrap-fetch-scenario
   [handler {:keys [scenarios projects2]}]

--- a/src/planwise/engine/suggestions.clj
+++ b/src/planwise/engine/suggestions.clj
@@ -193,8 +193,9 @@
                 demand-covered (:demand-covered result)]
             (demand/multiply-population-under-coverage! raster p-coverage 0.0)
             (remove-demand-point! raster p-max)
-            {:location {:location (select-keys result [:lat :lon])
-                        :coverage demand-covered}
+            {:location {:location  (select-keys result [:lat :lon])
+                        :iteration iteration
+                        :coverage  demand-covered}
              :run-data run-data})
           (do
             ;; coverage for point cannot be resolved; remove it from the set and continue


### PR DESCRIPTION
Closes #695 

- Show a message in the sidebar while creating a new provider
- Refactor: simplify and improve suggestions handling code in the client
- Render marker icons according to the type of suggestion, both in the map and the suggestions list
- When selecting suggestions, render the coverage of the suggestion
- Dim existing providers and changes while selecting from a list of suggestions
- Unselect providers when selecting suggestions and viceversa
- Restore UI state after creating a new change from a suggestion or from clicking on the map
- Hide delete button in change dialog if the change is new

![Screenshot from 2021-12-13 11-24-49](https://user-images.githubusercontent.com/733591/145829861-61e61306-a9e5-4f69-b03b-813629824991.png)
![Screenshot from 2021-12-13 11-25-41](https://user-images.githubusercontent.com/733591/145829886-edf55bb1-f2af-493c-a9c0-f5a409a8cfa6.png)
![Screenshot from 2021-12-13 11-27-26](https://user-images.githubusercontent.com/733591/145830158-3039c36d-89a5-466f-98a4-470a383b355f.png)
