### PR TITLE
Build & deploy Docker images for mapserver and mapcache customizations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
 
   mapserver:
     docker:
-      - image: docker:20-git
+      - image: cimg/base:stable
     working_directory: ~/repo
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,16 @@ jobs:
       - run: |
           ./deploy.sh ${CIRCLE_TAG:-${CIRCLE_BRANCH/#master/latest}}
 
+  mapserver:
+    docker:
+      - image: docker:20-git
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run: |
+          ./mapserver/deploy.sh ${CIRCLE_TAG:-${CIRCLE_BRANCH/#master/latest}}
+
 workflows:
   version: 2
   ci:
@@ -93,3 +103,6 @@ workflows:
             tags:
               only:
                 - /[0-9]+(\.[0-9]+)*(-pre\d+)?/
+      - mapserver:
+          requires:
+            - deploy

--- a/mapserver/deploy.sh
+++ b/mapserver/deploy.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euo pipefail
+
+cd $(dirname $0)
+
+# To be invoked from circleci
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 DOCKER_TAG"
+	exit 1
+fi
+
+TAG=${1/\//_}
+
+MAPCACHE_TAG=instedd/planwise-mapserver:mapcache-$TAG
+MAPSERVER_TAG=instedd/planwise-mapserver:mapserver-$TAG
+
+docker login -u ${DOCKER_USER} -p ${DOCKER_PASS} ${DOCKER_REGISTRY}
+docker build -t $MAPSERVER_TAG -f Dockerfile.mapserver .
+docker build -t $MAPCACHE_TAG -f Dockerfile.mapcache .
+docker push $MAPSERVER_TAG
+docker push $MAPCACHE_TAG


### PR DESCRIPTION
Closes #706 

Add a workflow job to the CircleCI configuration to build and push Docker images for mapserver and mapcache after a successful push of the application image.
