### PR TITLE
Feature/693 cluster facilities

### DIFF
--- a/client/resources/sass/site2.scss
+++ b/client/resources/sass/site2.scss
@@ -1313,6 +1313,45 @@ form.vertical, .fields-vertical {
   }
 }
 
+.cluster-provider-icon {
+  border-radius: 50%;
+  box-sizing: border-box;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.38),
+              0 4px 0 #eee,
+              0 4px 2px rgba(0,0,0,0.68),
+              0 8px 0 #eee,
+              0 8px 2px rgba(0,0,0,0.68);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+
+  &[style] {
+    margin-left: -14px !important;
+    margin-top: -14px !important;
+    width: 28px !important;
+    height: 28px !important;
+  }
+
+  b {
+    color: white;
+  }
+
+  border: 2px white solid;
+  &.idle-capacity {
+    background-color: #673AB7;
+  }
+  &.at-capacity {
+    background-color: black;
+  }
+  &.unsatisfied {
+    background-color: #ff5722;
+  }
+  &.upgradeable {
+    background-color: #999;
+  }
+}
+
 path.coverage-polygon {
   stroke: black;
   stroke-opacity: 1;

--- a/client/resources/sass/site2.scss
+++ b/client/resources/sass/site2.scss
@@ -1404,6 +1404,57 @@ path.coverage-polygon {
   }
 }
 
+.cluster-source-icon {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: black;
+
+  b {
+    color: black;
+    font-size: 16px;
+    position: absolute;
+  }
+  &.satisfied b {
+    color: white;
+  }
+
+  &::before {
+    position: absolute;
+    content: " ";
+    display: block;
+    width: 24px;
+    height: 24px;
+    border: 2px solid white;
+    background: black;
+    transform: rotate(45deg);
+    box-shadow: 0 1px 3px rgba(0,0,0,0.34),
+                3px 3px 0 #eee,
+                3px 3px 2px rgba(0,0,0,0.68),
+                6px 6px 0 #eee,
+                6px 6px 2px rgba(0,0,0,0.68);
+  }
+  &.gray::before {
+    background: darkgray;
+  }
+  &.satisfied::before {
+    background: black;
+  }
+  &.q1::before {
+    background: rgb(251,251,121);
+  }
+  &.q2::before {
+    background: rgb(241,195,85);
+  }
+  &.q3::before {
+    background: rgb(232,139,49);
+  }
+  &.q4::before {
+    background: rgb(223,84,14);
+  }
+}
+
 //
 // Suggestions markers
 //

--- a/client/src/planwise/client/scenarios/views.cljs
+++ b/client/src/planwise/client/scenarios/views.cljs
@@ -164,9 +164,6 @@
       {:className
        (join " " (conj base-classes (when (not matches-filters) "upgradeable")))})))
 
-(defn- spiderfy-cluster [cluster]
-  (.spiderfy (. cluster -layer)))
-
 (defn- provider-cluster-icon-fn
   [cluster]
   (let [markers (.getAllChildMarkers cluster)
@@ -188,12 +185,8 @@
         all-providers        @(subscribe [:scenarios/all-providers])
         demand-unit          (get-demand-unit project)
         capacity-unit        (get-capacity-unit project)]
-    (into [:cluster-group {:key                 "providers-layer"
-                           :showCoverageOnHover false
-                           :zoomToBoundsOnClick false
-                           :maxClusterRadius    50
-                           :cluster-icon-fn     provider-cluster-icon-fn
-                           :cluster-click-fn    spiderfy-cluster}]
+    (into [:cluster-group {:key             "providers-layer"
+                           :cluster-icon-fn provider-cluster-icon-fn}]
           (map (fn [{:keys [id location name] :as provider}]
                  (let [selected?    (= id (:id selected-provider))
                        disabled?    (or listing-suggestions?
@@ -362,12 +355,8 @@
   [{:keys [project scenario]}]
   (let [demand-unit  (get-demand-unit project)
         sources-data (:sources-data scenario)]
-    (into [:cluster-group {:key                 "sources-layer"
-                           :showCoverageOnHover false
-                           :zoomToBoundsOnClick false
-                           :maxClusterRadius    50
-                           :cluster-icon-fn     source-cluster-icon-fn
-                           :cluster-click-fn    spiderfy-cluster}]
+    (into [:cluster-group {:key             "sources-layer"
+                           :cluster-icon-fn source-cluster-icon-fn}]
           (map (fn [{:keys [id lat lon name] :as source}]
                  [:marker {:key          id
                            :lat          lat

--- a/client/src/planwise/client/scenarios/views.cljs
+++ b/client/src/planwise/client/scenarios/views.cljs
@@ -157,6 +157,9 @@
       {:className
        (join " " (conj base-classes (when (not matches-filters) "upgradeable")))})))
 
+(defn- spiderfy-cluster [cluster]
+  (.spiderfy (. cluster -layer)))
+
 (defn- scenario-providers-layer
   [{:keys [project scenario click-fn popup-fn mouseover-fn mouseout-fn]}]
   (let [selected-provider    @(subscribe [:scenarios.map/selected-provider])
@@ -166,7 +169,11 @@
         all-providers        @(subscribe [:scenarios/all-providers])
         demand-unit          (get-demand-unit project)
         capacity-unit        (get-capacity-unit project)]
-    (into [:feature-group {:key "providers-layer"}]
+    (into [:cluster-group {:key                 "providers-layer"
+                           :showCoverageOnHover false
+                           :zoomToBoundsOnClick false
+                           :maxClusterRadius    50
+                           :cluster-click-fn    spiderfy-cluster}]
           (map (fn [{:keys [id location name] :as provider}]
                  (let [selected?    (= id (:id selected-provider))
                        disabled?    (or listing-suggestions?
@@ -180,12 +187,13 @@
                                      :provider     provider
                                      :zIndexOffset (if (provider-has-change? provider) 3000 2000)}]
                    [:marker (merge marker-props
-                                   (when-not disabled?
+                                   (if disabled?
+                                     {:opacity 0.3}
                                      {:tooltip      (provider-tooltip {:demand-unit   demand-unit
                                                                        :capacity-unit capacity-unit}
                                                                       provider)
-                                      :open?        (when selected? (:open? selected-provider))
-                                      :hover?       (when selected? (:hover? selected-provider))
+                                      :opacity      1.0
+                                      :hover?       selected?
                                       :click-fn     click-fn
                                       :popup-fn     popup-fn
                                       :mouseover-fn mouseover-fn

--- a/project.clj
+++ b/project.clj
@@ -50,7 +50,8 @@
 
                  ; Client assets and components
                  [org.webjars/normalize.css "5.0.0"]
-                 [org.webjars/leaflet "1.3.1"]
+                 [org.webjars/leaflet "1.7.1"]
+                 [org.webjars/leaflet-markercluster "1.4.1"]
 
                  ; Database access
                  [org.clojure/java.jdbc "0.7.5"]

--- a/src/planwise/endpoint/home.clj
+++ b/src/planwise/endpoint/home.clj
@@ -29,7 +29,6 @@
    [:title "PlanWise"]
    (include-css "/assets/leaflet/leaflet.css")
    (include-css "/assets/leaflet-markercluster/MarkerCluster.css")
-   (include-css "/assets/leaflet-markercluster/MarkerCluster.Default.css")
    (include-css "/css/site2.css")
    [:link {:href "https://fonts.googleapis.com/css?family=Roboto:300,400,500" :rel "stylesheet"}]
    [:link {:href "https://fonts.googleapis.com/icon?family=Material+Icons" :rel "stylesheet"}]])

--- a/src/planwise/endpoint/home.clj
+++ b/src/planwise/endpoint/home.clj
@@ -28,6 +28,8 @@
            :content "width=device-width, initial-scale=1"}]
    [:title "PlanWise"]
    (include-css "/assets/leaflet/leaflet.css")
+   (include-css "/assets/leaflet-markercluster/MarkerCluster.css")
+   (include-css "/assets/leaflet-markercluster/MarkerCluster.Default.css")
    (include-css "/css/site2.css")
    [:link {:href "https://fonts.googleapis.com/css?family=Roboto:300,400,500" :rel "stylesheet"}]
    [:link {:href "https://fonts.googleapis.com/icon?family=Material+Icons" :rel "stylesheet"}]])
@@ -59,6 +61,7 @@
       (anti-forgery-field)
       (client-config (assoc endpoint :request request))
       (include-js "/assets/leaflet/leaflet.js")
+      (include-js "/assets/leaflet-markercluster/leaflet.markercluster.js")
       (include-js "/js/leaflet.ext.js")
       (include-js "/js/main.js")
       [:script "planwise.client.core.main();"]])))


### PR DESCRIPTION
Close #693 

Uses [Leafleft.MarkerCluster](https://github.com/Leaflet/Leaflet.markercluster) to render providers and source points in the map.

Bonus:
- upgrade Leaflet to 1.7.1
- update LayerGroups and Markers instead of recreating the markers contained. This reduces flickering while interacting with the map and it should be more efficient overall.

![Screenshot from 2022-06-21 19-14-45](https://user-images.githubusercontent.com/733591/174906212-70b68f10-21fe-4255-a746-5d435e5b726f.png)
![Screenshot from 2022-06-21 19-15-06](https://user-images.githubusercontent.com/733591/174906215-51665856-9160-49e7-b32e-f27e9e5f64fc.png)
![Screenshot from 2022-06-21 19-15-28](https://user-images.githubusercontent.com/733591/174906221-f9bdb60f-362f-4dcd-b87a-0f4bc3721e3e.png)
