### PR TITLE
Add proxy-aware middleware to server

### DIFF
--- a/src/planwise/middleware.clj
+++ b/src/planwise/middleware.clj
@@ -103,6 +103,7 @@
                                          session-config
                                          {:session {:flash true
                                                     :store session-store}
+                                          :proxy true
                                           :static  {:resources "planwise/public"}})]
     (let [middleware [#(wrap-not-found % (html-response error-404))
                       wrap-webjars


### PR DESCRIPTION
In order to honour `X-Forwarded-Proto` and other headers that are added when running the app behind a reverse-proxy, we add relevant middleware to the app.

Specifically, this will make `absolute-url` properly work.

Fixes #716