### PR TITLE
Use autoselect control for Providers

### DIFF
--- a/client/src/planwise/client/projects2/components/settings.cljs
+++ b/client/src/planwise/client/projects2/components/settings.cljs
@@ -236,7 +236,6 @@
         provider-unit   (get-provider-unit @current-project)
         demand-unit     (get-demand-unit @current-project)
         capacity-unit   (get-capacity-unit @current-project)]
-    (dispatch [:providers-set/load-providers-set])
     [:section {:class-name "project-settings-section"}
      [section-header 3 "Providers"]
      [providers-set-dropdown-component {:label     "Provider Dataset"

--- a/client/src/planwise/client/projects2/components/settings.cljs
+++ b/client/src/planwise/client/projects2/components/settings.cljs
@@ -236,10 +236,11 @@
         provider-unit   (get-provider-unit @current-project)
         demand-unit     (get-demand-unit @current-project)
         capacity-unit   (get-capacity-unit @current-project)]
+    (dispatch [:providers-set/load-providers-set])
     [:section {:class-name "project-settings-section"}
      [section-header 3 "Providers"]
      [providers-set-dropdown-component {:label     "Provider Dataset"
-                                        :value     (:provider-set-id @current-project)
+                                        :model     (:provider-set-id @current-project)
                                         :on-change #(dispatch [:projects2/save-key :provider-set-id %])
                                         :disabled? read-only}]
 

--- a/client/src/planwise/client/providers_set/components/dropdown.cljs
+++ b/client/src/planwise/client/providers_set/components/dropdown.cljs
@@ -1,33 +1,12 @@
 (ns planwise.client.providers-set.components.dropdown
-  (:require [re-frame.core :refer [subscribe dispatch]]
-            [reagent.core :as r]
-            [clojure.string :as string]
-            [planwise.client.asdf :as asdf]
-            [planwise.client.utils :as utils]
-            [planwise.client.components.common2 :as common2]
-            [planwise.client.providers-set.db :as db]
-            [planwise.client.ui.rmwc :as m]
-            [re-frame.utils :as c]))
-
-(defn- providers-set-select-component
-  [{:keys [label value options empty-label on-change]}]
-  [m/Select {:label (if (empty? options) empty-label label)
-             :disabled (empty? options)
-             :value (str value)
-             :options options
-             :on-change #(on-change (js/parseInt (-> % .-target .-value)))}])
+  (:require [re-frame.core :as rf]
+            [planwise.client.ui.filter-select :as filter-select]))
 
 (defn providers-set-dropdown-component
-  [{:keys [label value on-change disabled?]}]
-  (let [list      (subscribe [:providers-set/list])
-        options   (subscribe [:providers-set/dropdown-options])
-        component (if (or disabled? (empty? @options))
-                    common2/disabled-input-component
-                    providers-set-select-component)]
-    (when (asdf/should-reload? @list)
-      (dispatch [:providers-set/load-providers-set]))
-    [component {:label        label
-                :value        value
-                :options      @options
-                :empty-label  "There are no providers-set defined."
-                :on-change    on-change}]))
+  [attrs]
+  (let [props (merge {:choices   @(rf/subscribe [:providers-set/dropdown-options])
+                      :label-fn  :label
+                      :render-fn (fn [provider-set] [:div.option-row
+                                               [:span (:label provider-set)]])}
+                     attrs)]
+    (into [filter-select/single-dropdown] (mapcat identity props))))

--- a/client/src/planwise/client/providers_set/components/dropdown.cljs
+++ b/client/src/planwise/client/providers_set/components/dropdown.cljs
@@ -9,7 +9,7 @@
         props (merge {:choices   @(rf/subscribe [:providers-set/dropdown-options])
                       :label-fn  :label
                       :render-fn (fn [provider-set] [:div.option-row
-                                               [:span (:label provider-set)]])}
+                                                     [:span (:label provider-set)]])}
                      attrs)]
     (when (asdf/should-reload? @list)
       (rf/dispatch [:providers-set/load-providers-set]))

--- a/client/src/planwise/client/providers_set/components/dropdown.cljs
+++ b/client/src/planwise/client/providers_set/components/dropdown.cljs
@@ -1,12 +1,16 @@
 (ns planwise.client.providers-set.components.dropdown
   (:require [re-frame.core :as rf]
+            [planwise.client.asdf :as asdf]
             [planwise.client.ui.filter-select :as filter-select]))
 
 (defn providers-set-dropdown-component
   [attrs]
-  (let [props (merge {:choices   @(rf/subscribe [:providers-set/dropdown-options])
+  (let [list  (rf/subscribe [:providers-set/list])
+        props (merge {:choices   @(rf/subscribe [:providers-set/dropdown-options])
                       :label-fn  :label
                       :render-fn (fn [provider-set] [:div.option-row
                                                [:span (:label provider-set)]])}
                      attrs)]
+    (when (asdf/should-reload? @list)
+      (rf/dispatch [:providers-set/load-providers-set]))
     (into [filter-select/single-dropdown] (mapcat identity props))))

--- a/client/src/planwise/client/providers_set/subs.cljs
+++ b/client/src/planwise/client/providers_set/subs.cljs
@@ -15,9 +15,9 @@
      (->> providers
           (map (fn [provider-set]
                  (let [{:keys [id name]} provider-set]
-                   {:value id :label name})))
+                   {:value id :label name :id id})))
           (sort-by :label)
-          (into [{:value nil :label "None"}])))))
+          (into [{:value nil :label "None" :id nil}])))))
 
 (rf/reg-sub
  :providers-set/view-state


### PR DESCRIPTION
So it matches both the Region and Consumers pickers.

![Screenshot of the component showing two fake-sample entries being filtered](https://github.com/instedd/planwise/assets/5470539/d1a55a32-e4f2-489c-a33c-2f3ad9132fed)

See #724