### PR TITLE
fix: Don't double capacity on data returned in providers CSV

### DIFF
--- a/src/planwise/component/engine.clj
+++ b/src/planwise/component/engine.clj
@@ -14,7 +14,7 @@
             [planwise.util.geo :as geo]
             [planwise.util.files :as files]
             [planwise.util.numbers :refer [abs float=]]
-            [planwise.model.providers :refer [merge-providers merge-provider]]
+            [planwise.model.providers :refer [merge-providers]]
             [planwise.util.collections :refer [sum-by merge-collections-by]]
             [integrant.core :as ig]
             [clojure.java.io :as io]

--- a/src/planwise/component/providers_set.clj
+++ b/src/planwise/component/providers_set.clj
@@ -9,6 +9,7 @@
             [hugsql.core :as hugsql]
             [clojure.edn :as edn]
             [planwise.util.files :as files]
+            [planwise.util.collections :refer [csv-data->maps]]
             [clojure.string :as str]
             [clojure.set :as set]))
 
@@ -22,14 +23,6 @@
 (defn get-db
   [store]
   (get-in store [:db :spec]))
-
-(defn- csv-data->maps
-  [csv-data]
-  (map zipmap
-       (->> (first csv-data)
-            (map keyword)
-            repeat)
-       (rest csv-data)))
 
 (defn- import-provider
   [store provider-set-id version csv-provider-data]

--- a/src/planwise/component/scenarios.clj
+++ b/src/planwise/component/scenarios.clj
@@ -374,9 +374,16 @@
                                                 provider-set-id
                                                 (:provider-set-version project)
                                                 filter-options)
-        disabled-providers                     (map #(assoc % :capacity 0) disabled-providers)
         new-providers                          (new-providers-to-export (:changeset scenario))
-        fields                                 [:id :type :name :lat :lon :tags :capacity :required-capacity :used-capacity :satisfied-demand :unsatisfied-demand]]
+        ;; final capacity for the scenario is stored in the scenario's :providers-data
+        ;; so we remove it from the "base" collections to avoid adding them up
+        ;; (and duplicating it) by merge-providers
+        disabled-providers                     (map #(dissoc % :capacity) disabled-providers)
+        providers                              (map #(dissoc % :capacity) providers)
+        new-providers                          (map #(dissoc % :capacity) new-providers)
+        fields                                 [:id :type :name :lat :lon :tags
+                                                :capacity :required-capacity :used-capacity
+                                                :satisfied-demand :unsatisfied-demand]]
     (map->csv
      (merge-providers providers disabled-providers new-providers (:providers-data scenario))
      fields)))

--- a/src/planwise/util/collections.clj
+++ b/src/planwise/util/collections.clj
@@ -16,3 +16,13 @@
 (defn map-vals
   [f m]
   (reduce-kv (fn [acc k v] (assoc acc k (f v))) {} m))
+
+(defn csv-data->maps
+  "Converts the result of csv/read-csv (ie. a collection of vectors of strings)
+  into a collection of maps using the first row (converted to keywords) as keys"
+  [csv-data]
+  (map zipmap
+       (->> (first csv-data)
+            (map keyword)
+            repeat)
+       (rest csv-data)))


### PR DESCRIPTION
Fixes #726 

We're using `merge-providers` to construct the final data to export, which gathers providers and their attributes from several sources: providers set, scenario changeset and scenario providers data. Since `merge-providers` adds up its numeric fields, we were adding the capacity both from the final value found in `:providers-data` and the original provider set and/or the changeset.