### PR TITLE
fix: Sanitize tags for filtering providers in projects

### DIFF
--- a/client/src/planwise/client/projects2/handlers.cljs
+++ b/client/src/planwise/client/projects2/handlers.cljs
@@ -6,6 +6,8 @@
             [planwise.client.effects :as effects]
             [planwise.client.projects2.db :as db]
             [planwise.client.utils :as utils]
+            [planwise.common :as common]
+            [clojure.string :as string]
             [clojure.spec.alpha :as s]))
 
 
@@ -270,10 +272,12 @@
  :projects2/save-tag
  in-projects2
  (fn [{:keys [db]} [_ tag]]
-   (let [path [:current-project :config :providers :tags]
-         n (count (get-in db path))]
-     {:db       (update-in db path (comp vec conj) tag)
-      :dispatch [:projects2/persist-current-project]})))
+   (let [tag  (common/sanitize-tag tag)
+         path [:current-project :config :providers :tags]
+         n    (count (get-in db path))]
+     (when-not (string/blank? tag)
+       {:db       (update-in db path (comp vec conj) tag)
+        :dispatch [:projects2/persist-current-project]}))))
 
 (rf/reg-event-fx
  :projects2/delete-tag

--- a/common/src/planwise/common.cljc
+++ b/common/src/planwise/common.cljc
@@ -1,5 +1,5 @@
 (ns planwise.common
-  (:require [clojure.string :refer [lower-case]]))
+  (:require [clojure.string :as string :refer [lower-case]]))
 
 (defn is-budget
   [analysis-type]
@@ -47,3 +47,10 @@
    (get-capacity-unit project true))
   ([project lowercase?]
    (get-project-unit project [:config :providers :capacity-unit] "units" lowercase?)))
+
+(defn sanitize-tag
+  [tag]
+  (-> tag
+      string/trim
+      (string/replace #"\s+" "-")
+      (string/replace #"[^a-zA-Z0-9.-]" "")))

--- a/test/planwise/component/providers_set_test.clj
+++ b/test/planwise/component/providers_set_test.clj
@@ -5,6 +5,7 @@
             [planwise.component.providers-set :as providers-set]
             [planwise.boundary.projects2 :as projects2]
             [planwise.test-system :as test-system]
+            [planwise.common :as common]
             [clj-time.core :as time]
             [integrant.core :as ig])
   (:import [org.postgis PGgeometry]))
@@ -159,7 +160,7 @@
 
 (defn- validate-filter-count
   [store id tags number]
-  (is (= (:filtered (providers-set/count-providers-filter-by-tags store id 1 tags)) number)))
+  (is (= number (:filtered (providers-set/count-providers-filter-by-tags store id 1 tags)))))
 
 (deftest filtering-providers
   (test-system/with-system (test-config fixture-filtering-providers-tags)
@@ -170,7 +171,14 @@
       (validate-filter-count store 1 ["inexistent"] 0)
       (validate-filter-count store 1 ["private"] 2)
       (validate-filter-count store 2 ["private"] 0)
-      (validate-filter-count store 2 ["-"] 0))))
+      (validate-filter-count store 2 ["-"] 0)
+      ;; sanitizes input tags
+      (validate-filter-count store 1 ["pri&vate"] 2))))
+
+(deftest sanitize-tag
+  (is (= "" (common/sanitize-tag "&|")))
+  (is (= "general-medicine" (common/sanitize-tag "general medicine")))
+  (is (= "private" (common/sanitize-tag "pri&vate"))))
 
 ;; ----------------------------------------------------------------------
 ;; Testing deleting provider-set


### PR DESCRIPTION
Fixes #728

Delete all non-alpha characters and replace whitespace with `-` in provider filtering tags when configuring a project and also when querying the providers for building the scenarios.